### PR TITLE
feat: JWT 및 OAuth 로그인/로그아웃 기능 및 테스트 코드 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -14,6 +14,9 @@ java {
 	}
 }
 
+tasks.named('compileJava', JavaCompile) {
+	options.compilerArgs.add('-parameters')
+}
 
 dependencyManagement {
 	imports {
@@ -33,18 +36,31 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	implementation 'javax.xml.bind:jaxb-api:2.3.1'
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1'
+	implementation 'io.github.cdimascio:java-dotenv:5.2.2'
+
+	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	testImplementation 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	implementation 'io.github.cdimascio:java-dotenv:5.2.2'
-	runtimeOnly 'com.h2database:h2'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: kbosung/study-app:latest # 현재 디렉토리의 Dockerfile을 사용해 이미지를 빌드
     container_name: my-app
     ports:
-      - "8080:8080" # 호스트 PC의 8080 포트와 컨테이너의 8080 포트 연결
+      - "8081:8080" # 호스트 PC의 8080 포트와 컨테이너의 8080 포트 연결
     environment:
       # Spring Boot 애플리케이션이 사용할 환경 변수
       - SPRING_DATASOURCE_URL=jdbc:mysql://db:3306/${DB_NAME}

--- a/backend/src/main/java/com/study/focus/account/config/TokenAuthenticationFilter.java
+++ b/backend/src/main/java/com/study/focus/account/config/TokenAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package com.study.focus.account.config;
+
+import com.study.focus.account.config.jwt.TokenProvider;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class TokenAuthenticationFilter extends OncePerRequestFilter {
+
+    private final TokenProvider tokenProvider;
+    private final static String HEADER_AUTHORIZATION = "Authorization";
+    private final static String TOKEN_PREFIX = "Bearer ";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token) && tokenProvider.validateToken(token)) {
+            Claims claims = tokenProvider.getClaims(token);
+
+            Long userId = Long.valueOf(claims.getSubject()); // userId
+            String identifier = claims.get("identifier", String.class); // loginId or provider:providerId
+
+            // Authentication 객체 생성 (UserDetails 대신 최소한의 인증정보만 담음)
+            Authentication authentication =
+                    new UsernamePasswordAuthenticationToken(userId, identifier, null);
+
+            // SecurityContext에 등록
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(HEADER_AUTHORIZATION);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(TOKEN_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/com/study/focus/account/config/WebOAuthSecurityConfig.java
+++ b/backend/src/main/java/com/study/focus/account/config/WebOAuthSecurityConfig.java
@@ -1,0 +1,105 @@
+package com.study.focus.account.config;
+
+import com.study.focus.account.config.jwt.TokenProvider;
+import com.study.focus.account.config.oauth.OAuth2AuthorizationRequestBasedOnCookieRepository;
+import com.study.focus.account.config.oauth.OAuth2SuccessHandler;
+import com.study.focus.account.config.oauth.OAuth2UserCustomService;
+import com.study.focus.account.service.AccountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebOAuthSecurityConfig {
+
+    private final OAuth2UserCustomService oAuth2UserCustomService;
+    private final TokenProvider tokenProvider;
+
+    @Bean
+    public WebSecurityCustomizer configure() {
+        return (web) -> web.ignoring()
+                .requestMatchers(
+                        new AntPathRequestMatcher("/img/**"),
+                        new AntPathRequestMatcher("/css/**"),
+                        new AntPathRequestMatcher("/js/**")
+                );
+    }
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("http://localhost:8080") // 프론트 주소
+                        .allowedMethods("GET","POST","PUT","DELETE")
+                        .allowCredentials(true);
+            }
+        };
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http,
+                                           OAuth2SuccessHandler oAuth2SuccessHandler) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .sessionManagement(m -> m.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(tokenAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/login", "/api/auth/register", "/api/auth/token", "/api/auth/logout").permitAll()
+                        .requestMatchers(new AntPathRequestMatcher("/api/**")).authenticated()
+                        .anyRequest().permitAll())
+                .oauth2Login(oauth2 -> oauth2
+                        .loginPage("/login")
+                        .authorizationEndpoint(endpoint ->
+                                endpoint.authorizationRequestRepository(oAuth2AuthorizationRequestBasedOnCookieRepository()))
+                        .userInfoEndpoint(userInfoEndpoint -> userInfoEndpoint.userService(oAuth2UserCustomService))
+                        .successHandler(oAuth2SuccessHandler)
+                )
+                .exceptionHandling(e -> e
+                        .defaultAuthenticationEntryPointFor(
+                                new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED),
+                                new AntPathRequestMatcher("/api/**")
+                        ))
+                .build();
+    }
+
+    @Bean
+    public OAuth2SuccessHandler oAuth2SuccessHandler(AccountService accountService) {
+        return new OAuth2SuccessHandler(
+                accountService,
+                oAuth2AuthorizationRequestBasedOnCookieRepository()
+        );
+    }
+
+    @Bean
+    public TokenAuthenticationFilter tokenAuthenticationFilter() {
+        return new TokenAuthenticationFilter(tokenProvider);
+    }
+
+    @Bean
+    public OAuth2AuthorizationRequestBasedOnCookieRepository oAuth2AuthorizationRequestBasedOnCookieRepository() {
+        return new OAuth2AuthorizationRequestBasedOnCookieRepository();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend/src/main/java/com/study/focus/account/config/jwt/JwtProperties.java
+++ b/backend/src/main/java/com/study/focus/account/config/jwt/JwtProperties.java
@@ -1,0 +1,18 @@
+package com.study.focus.account.config.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+    private String issuer;
+    private String secretKey;
+    private long accessTokenExpiry;
+    private long refreshTokenExpiry;
+}

--- a/backend/src/main/java/com/study/focus/account/config/jwt/TokenProvider.java
+++ b/backend/src/main/java/com/study/focus/account/config/jwt/TokenProvider.java
@@ -1,0 +1,81 @@
+package com.study.focus.account.config.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class TokenProvider {
+
+    private final JwtProperties jwtProperties;
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        byte[] keyBytes = Decoders.BASE64.decode(jwtProperties.getSecretKey());
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String createAccessToken(Long userId, String identifier) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + jwtProperties.getAccessTokenExpiry());
+
+        return Jwts.builder()
+                .setSubject(userId.toString())
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .claim("identifier", identifier)
+                .setIssuer(jwtProperties.getIssuer())
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String createRefreshToken(Long userId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + jwtProperties.getRefreshTokenExpiry());
+
+        return Jwts.builder()
+                .setSubject(userId.toString())
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Long getRefreshTokenExpiry() {
+        return jwtProperties.getRefreshTokenExpiry();
+    }
+
+    public Long getUserIdFromToken(String token) {
+        return Long.valueOf(parseClaims(token).getSubject());
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public Claims getClaims(String token) {
+        return parseClaims(token);
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/backend/src/main/java/com/study/focus/account/config/oauth/CustomOAuth2User.java
+++ b/backend/src/main/java/com/study/focus/account/config/oauth/CustomOAuth2User.java
@@ -1,0 +1,39 @@
+package com.study.focus.account.config.oauth;
+
+import com.study.focus.account.dto.TokenResponse;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class CustomOAuth2User implements OAuth2User {
+
+    private final Long userId;  // User 전체 대신 PK만 보관
+    private final Map<String, Object> attributes;
+    private final TokenResponse tokenResponse;
+
+    public CustomOAuth2User(Long userId, Map<String, Object> attributes, TokenResponse tokenResponse) {
+        this.userId = userId;
+        this.attributes = attributes;
+        this.tokenResponse = tokenResponse;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(() -> "ROLE_USER");
+    }
+
+    @Override
+    public String getName() {
+        return userId.toString();
+    }
+}

--- a/backend/src/main/java/com/study/focus/account/config/oauth/OAuth2AuthorizationRequestBasedOnCookieRepository.java
+++ b/backend/src/main/java/com/study/focus/account/config/oauth/OAuth2AuthorizationRequestBasedOnCookieRepository.java
@@ -1,0 +1,44 @@
+package com.study.focus.account.config.oauth;
+
+import com.study.focus.common.util.CookieUtil;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.web.util.WebUtils;
+
+public class OAuth2AuthorizationRequestBasedOnCookieRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+    public final static String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    private final static int COOKIE_EXPIRE_SECONDS = 18000;
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest
+                                                                         request, HttpServletResponse response) {
+        return this.loadAuthorizationRequest(request);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest
+                                                                       request) {
+        Cookie cookie = WebUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        return CookieUtil.deserialize(cookie, OAuth2AuthorizationRequest.class);
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest
+                                                 authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+
+        if (authorizationRequest == null) {
+            removeAuthorizationRequestCookies(request, response);
+            return;
+        }
+        CookieUtil.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+                CookieUtil.serialize(authorizationRequest), COOKIE_EXPIRE_SECONDS);
+    }
+
+    public void removeAuthorizationRequestCookies(HttpServletRequest request,
+                                                  HttpServletResponse response) {
+        CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+    }
+}

--- a/backend/src/main/java/com/study/focus/account/config/oauth/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/study/focus/account/config/oauth/OAuth2SuccessHandler.java
@@ -1,0 +1,81 @@
+package com.study.focus.account.config.oauth;
+
+import com.study.focus.account.domain.Provider;
+import com.study.focus.account.dto.LoginResponse;
+import com.study.focus.account.service.AccountService;
+import com.study.focus.common.util.CookieUtil;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
+    public static final Duration REFRESH_TOKEN_DURATION = Duration.ofDays(14);
+    public static final String REDIRECT_PATH = "/home";
+
+    private final AccountService accountService;
+    private final OAuth2AuthorizationRequestBasedOnCookieRepository authorizationRequestRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        String registrationId = ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId();
+        Provider provider = Provider.valueOf(registrationId.toUpperCase());
+
+        // providerUserId 추출
+        String providerUserId = extractProviderUserId(provider, oAuth2User.getAttributes());
+
+        // AccountService에 위임 (유저 조회/생성, 토큰 발급, RefreshToken 저장)
+        LoginResponse loginResponse = accountService.oauthLogin(provider, providerUserId);
+
+        // RefreshToken을 쿠키에 저장
+        addRefreshTokenToCookie(request, response, loginResponse.getRefreshToken());
+
+        // AccessToken을 포함한 리다이렉트 URL 생성
+        String targetUrl = getTargetUrl(loginResponse.getAccessToken());
+
+        clearAuthenticationAttributes(request, response);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+
+    private String extractProviderUserId(Provider provider, Map<String, Object> attributes) {
+
+        return switch (provider) {
+            case GOOGLE -> (String) attributes.get("sub");
+            case KAKAO -> String.valueOf(attributes.get("id"));
+            case NAVER -> ((Map<String, Object>) attributes.get("response")).get("id").toString();
+            default -> throw new IllegalArgumentException("지원하지 않는 Provider: " + provider);
+        };
+    }
+
+    private void addRefreshTokenToCookie(HttpServletRequest request, HttpServletResponse response, String refreshToken) {
+        int cookieMaxAge = (int) REFRESH_TOKEN_DURATION.toSeconds();
+        CookieUtil.deleteCookie(request, response, REFRESH_TOKEN_COOKIE_NAME);
+        CookieUtil.addCookie(response, REFRESH_TOKEN_COOKIE_NAME, refreshToken, cookieMaxAge);
+    }
+
+    private void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
+        super.clearAuthenticationAttributes(request);
+        authorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+    }
+
+    private String getTargetUrl(String token) {
+        return UriComponentsBuilder.fromUriString(REDIRECT_PATH)
+                .queryParam("token", token)
+                .build()
+                .toUriString();
+    }
+}

--- a/backend/src/main/java/com/study/focus/account/config/oauth/OAuth2UserCustomService.java
+++ b/backend/src/main/java/com/study/focus/account/config/oauth/OAuth2UserCustomService.java
@@ -1,0 +1,73 @@
+package com.study.focus.account.config.oauth;
+
+import com.study.focus.account.domain.LoginType;
+import com.study.focus.account.domain.OAuthCredential;
+import com.study.focus.account.domain.Provider;
+import com.study.focus.account.domain.User;
+import com.study.focus.account.repository.OAuthCredentialRepository;
+import com.study.focus.account.repository.UserRepository;
+import com.study.focus.account.service.RefreshTokenService;
+import com.study.focus.account.service.TokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class OAuth2UserCustomService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+    private final OAuthCredentialRepository oAuthCredentialRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId(); // google, kakao, naver
+        Provider provider = Provider.valueOf(registrationId.toUpperCase());
+
+        System.out.println("registrationId = " + registrationId);
+        System.out.println("provider = " + provider);
+
+        // providerId 추출 (각 provider별로 다름)
+        String providerUserId = extractProviderId(provider, oAuth2User.getAttributes());
+
+        // Credential 확인
+        OAuthCredential credential = oAuthCredentialRepository.findByProviderAndProviderUserId(provider, providerUserId)
+                .orElseGet(() -> {
+                    // 신규 사용자 → User 생성
+                    User newUser = User.builder()
+                            .loginType(LoginType.OAUTH)
+                            .build();
+                    userRepository.save(newUser);
+
+                    OAuthCredential newCredential = OAuthCredential.builder()
+                            .provider(provider)
+                            .providerUserId(providerUserId)
+                            .user(newUser)
+                            .build();
+                    return oAuthCredentialRepository.save(newCredential);
+                });
+
+        User user = credential.getUser();
+        user.updateLastLoginAt();
+
+        // 여기서는 단순히 UserId만 CustomOAuth2User로 넘김
+        return new CustomOAuth2User(user.getId(), oAuth2User.getAttributes(), null);
+    }
+
+    private String extractProviderId(Provider provider, Map<String, Object> attributes) {
+        return switch (provider) {
+            case GOOGLE -> (String) attributes.get("sub");
+            case KAKAO -> String.valueOf(attributes.get("id")); // Long → String 변환
+            case NAVER -> ((Map<String, Object>) attributes.get("response")).get("id").toString();
+            default -> throw new IllegalArgumentException("지원하지 않는 OAuth Provider입니다: " + provider);
+        };
+    }
+}

--- a/backend/src/main/java/com/study/focus/account/config/oauth/OAuth2UserCustomService.java
+++ b/backend/src/main/java/com/study/focus/account/config/oauth/OAuth2UserCustomService.java
@@ -32,9 +32,6 @@ public class OAuth2UserCustomService extends DefaultOAuth2UserService {
         String registrationId = userRequest.getClientRegistration().getRegistrationId(); // google, kakao, naver
         Provider provider = Provider.valueOf(registrationId.toUpperCase());
 
-        System.out.println("registrationId = " + registrationId);
-        System.out.println("provider = " + provider);
-
         // providerId 추출 (각 provider별로 다름)
         String providerUserId = extractProviderId(provider, oAuth2User.getAttributes());
 

--- a/backend/src/main/java/com/study/focus/account/controller/AuthController.java
+++ b/backend/src/main/java/com/study/focus/account/controller/AuthController.java
@@ -1,28 +1,89 @@
 package com.study.focus.account.controller;
 
+import com.study.focus.account.domain.Provider;
+import com.study.focus.account.dto.*;
+import com.study.focus.account.service.AccountService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.time.Duration;
 
 @RestController
 @RequestMapping("/api/auth")
+@RequiredArgsConstructor
 public class AuthController {
 
-    // OAuth 로그인
-    @PostMapping("/oauth/{provider}")
-    public void oauthLogin(@PathVariable String provider) {}
+    private final AccountService accountService;
+
+    // OAuth 로그인 -> OAuth2SuccessHandler 확인
+
+    // ✅ 프론트 연동용 OAuth 로그인 콜백 (JSON 응답)
+    @PostMapping("/oauth/callback")
+    public ResponseEntity<LoginResponse> oauthCallback(
+            @RequestParam("provider") String provider,
+            @RequestParam("providerUserId") String providerUserId) {
+
+        Provider enumProvider = Provider.valueOf(provider.toUpperCase());
+
+        LoginResponse loginResponse = accountService.oauthLogin(enumProvider, providerUserId);
+
+        return ResponseEntity.ok(loginResponse);
+    }
 
     // 회원가입
     @PostMapping("/register")
-    public void register() {}
+    public ResponseEntity<Void> register(@RequestBody RegisterRequest request) {
+        accountService.register(request);
+        return ResponseEntity.ok().build();
+    }
 
     // 아이디 중복 확인
     @GetMapping("/check-id")
-    public void checkId(@RequestParam String loginId) {}
+    public ResponseEntity<Void> checkId(@RequestParam String loginId) {
+        accountService.checkId(loginId);
+        return ResponseEntity.ok().build();
+    }
 
     // 일반 로그인
     @PostMapping("/login")
-    public void login() {}
+    public void login(@ModelAttribute LoginRequest request, HttpServletResponse response) throws IOException {
+        LoginResponse loginResponse = accountService.login(request);
+
+        // RefreshToken 쿠키 저장
+        Cookie cookie = new Cookie("refresh_token", loginResponse.getRefreshToken());
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false); // 로컬 테스트는 false, 배포는 true
+        cookie.setPath("/");
+        cookie.setMaxAge((int) Duration.ofDays(14).getSeconds());
+        response.addCookie(cookie);
+
+        // AccessToken 쿼리 파라미터로 전달
+        response.sendRedirect("/home.html?token=" + loginResponse.getAccessToken());
+    }
 
     // 로그아웃
     @PostMapping("/logout")
-    public void logout() {}
+    public ResponseEntity<Void> logout(@CookieValue(value = "refresh_token", required = false) String refreshToken,
+                                       HttpServletResponse response) {
+        if (refreshToken != null) {
+            accountService.logoutByRefreshToken(refreshToken);
+
+            // 쿠키 즉시 만료시키기
+            ResponseCookie deleteCookie = ResponseCookie.from("refresh_token", "")
+                    .httpOnly(true)
+                    .secure(true) // 배포 환경에서는 true
+                    .path("/")
+                    .maxAge(0) // 즉시 만료
+                    .build();
+            response.addHeader(HttpHeaders.SET_COOKIE, deleteCookie.toString());
+        }
+
+        return ResponseEntity.ok().build();
+    }
 }

--- a/backend/src/main/java/com/study/focus/account/controller/PageController.java
+++ b/backend/src/main/java/com/study/focus/account/controller/PageController.java
@@ -1,0 +1,26 @@
+package com.study.focus.account.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class PageController {
+
+    @GetMapping("/home")
+    public String home() {
+        // static/home.html 로 forward
+        return "forward:/home.html";
+    }
+
+    @GetMapping("/login")
+    public String login() {
+        return "forward:/login.html";
+    }
+
+    @GetMapping("/")
+    public String start() {
+        // 초기에 토큰 있으면 바로 로그인 + home으로
+        // 아니면 login으로
+        return "forward:/login.html";
+    }
+}

--- a/backend/src/main/java/com/study/focus/account/controller/TokenApiController.java
+++ b/backend/src/main/java/com/study/focus/account/controller/TokenApiController.java
@@ -1,0 +1,28 @@
+package com.study.focus.account.controller;
+
+import com.study.focus.account.dto.CreateAccessTokenRequest;
+import com.study.focus.account.dto.CreateAccessTokenResponse;
+import com.study.focus.account.service.TokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TokenApiController {
+
+    private final TokenService tokenService;
+
+    @PostMapping("/api/auth/token")
+    public ResponseEntity<CreateAccessTokenResponse> createNewAccessToken(
+            @CookieValue("refresh_token") String refreshToken) {
+        String newAccessToken = tokenService.createNewAccessToken(refreshToken);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new CreateAccessTokenResponse(newAccessToken));
+    }
+}

--- a/backend/src/main/java/com/study/focus/account/domain/LoginType.java
+++ b/backend/src/main/java/com/study/focus/account/domain/LoginType.java
@@ -1,0 +1,5 @@
+package com.study.focus.account.domain;
+
+public enum LoginType {
+    SYSTEM, OAUTH
+}

--- a/backend/src/main/java/com/study/focus/account/domain/RefreshToken.java
+++ b/backend/src/main/java/com/study/focus/account/domain/RefreshToken.java
@@ -1,0 +1,47 @@
+package com.study.focus.account.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 실제 refresh token 문자열
+    @Column(nullable = false, unique = true, length = 500)
+    private String token;
+
+    // 유효기간
+    @Column(nullable = false)
+    private LocalDateTime expiryDate;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    public RefreshToken(String token, LocalDateTime expiryDate, User user) {
+        this.token = token;
+        this.expiryDate = expiryDate;
+        this.user = user;
+    }
+
+    // === 편의 메서드 ===
+    public boolean isExpired() {
+        return expiryDate.isBefore(LocalDateTime.now());
+    }
+
+    public RefreshToken update(String newToken, LocalDateTime newExpiryDate) {
+        this.token = newToken;
+        this.expiryDate = newExpiryDate;
+        return this;
+    }
+}

--- a/backend/src/main/java/com/study/focus/account/domain/User.java
+++ b/backend/src/main/java/com/study/focus/account/domain/User.java
@@ -19,8 +19,17 @@ public class User extends BaseCreatedEntity {
     private Long id;
 
     @Column(nullable = false)
-    private long trustScore;
+    @Builder.Default
+    private long trustScore = 0;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
+    @Builder.Default
+    private LoginType loginType = LoginType.SYSTEM;
+
     private LocalDateTime lastLoginAt;
+
+    public void updateLastLoginAt() {
+        this.lastLoginAt = LocalDateTime.now();
+    }
 }

--- a/backend/src/main/java/com/study/focus/account/dto/CreateAccessTokenRequest.java
+++ b/backend/src/main/java/com/study/focus/account/dto/CreateAccessTokenRequest.java
@@ -1,0 +1,15 @@
+package com.study.focus.account.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreateAccessTokenRequest {
+
+    private String refreshToken;
+}

--- a/backend/src/main/java/com/study/focus/account/dto/CreateAccessTokenResponse.java
+++ b/backend/src/main/java/com/study/focus/account/dto/CreateAccessTokenResponse.java
@@ -1,0 +1,12 @@
+package com.study.focus.account.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CreateAccessTokenResponse {
+
+    private String accessToken;
+}
+

--- a/backend/src/main/java/com/study/focus/account/dto/LoginRequest.java
+++ b/backend/src/main/java/com/study/focus/account/dto/LoginRequest.java
@@ -1,0 +1,13 @@
+package com.study.focus.account.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginRequest {
+    private String loginId;
+    private String password;
+}

--- a/backend/src/main/java/com/study/focus/account/dto/LoginResponse.java
+++ b/backend/src/main/java/com/study/focus/account/dto/LoginResponse.java
@@ -1,0 +1,11 @@
+package com.study.focus.account.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class LoginResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/backend/src/main/java/com/study/focus/account/dto/RegisterRequest.java
+++ b/backend/src/main/java/com/study/focus/account/dto/RegisterRequest.java
@@ -1,0 +1,13 @@
+package com.study.focus.account.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RegisterRequest {
+    private String loginId;
+    private String password;
+}

--- a/backend/src/main/java/com/study/focus/account/dto/TokenRefreshRequest.java
+++ b/backend/src/main/java/com/study/focus/account/dto/TokenRefreshRequest.java
@@ -1,0 +1,8 @@
+package com.study.focus.account.dto;
+
+import lombok.Data;
+
+@Data
+public class TokenRefreshRequest {
+    private String refreshToken;
+}

--- a/backend/src/main/java/com/study/focus/account/dto/TokenResponse.java
+++ b/backend/src/main/java/com/study/focus/account/dto/TokenResponse.java
@@ -1,0 +1,12 @@
+package com.study.focus.account.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TokenResponse {
+    private String accessToken;
+    private String refreshToken;
+    private Long refreshTokenExpiry;
+}

--- a/backend/src/main/java/com/study/focus/account/repository/OAuthCredentialRepository.java
+++ b/backend/src/main/java/com/study/focus/account/repository/OAuthCredentialRepository.java
@@ -1,7 +1,14 @@
 package com.study.focus.account.repository;
 
 import com.study.focus.account.domain.OAuthCredential;
+import com.study.focus.account.domain.Provider;
+import com.study.focus.account.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface OAuthCredentialRepository extends JpaRepository<OAuthCredential, Long> {
+    Optional<OAuthCredential> findByProviderAndProviderUserId(Provider provider, String providerUserId);
+
+    Optional<OAuthCredential> findByUser(User user);
 }

--- a/backend/src/main/java/com/study/focus/account/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/study/focus/account/repository/RefreshTokenRepository.java
@@ -11,4 +11,5 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     Optional<RefreshToken> findByUser(User user);
     Optional<RefreshToken> findByUserId(Long userId);
     void deleteByUser(User user);
+    void deleteByUserId(Long userId);
 }

--- a/backend/src/main/java/com/study/focus/account/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/study/focus/account/repository/RefreshTokenRepository.java
@@ -1,0 +1,14 @@
+package com.study.focus.account.repository;
+
+import com.study.focus.account.domain.RefreshToken;
+import com.study.focus.account.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+    Optional<RefreshToken> findByUser(User user);
+    Optional<RefreshToken> findByUserId(Long userId);
+    void deleteByUser(User user);
+}

--- a/backend/src/main/java/com/study/focus/account/repository/SystemCredentialRepository.java
+++ b/backend/src/main/java/com/study/focus/account/repository/SystemCredentialRepository.java
@@ -1,7 +1,13 @@
 package com.study.focus.account.repository;
 
 import com.study.focus.account.domain.SystemCredential;
+import com.study.focus.account.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SystemCredentialRepository extends JpaRepository<SystemCredential, Long> {
+    boolean existsByLoginId(String loginId);
+    Optional<SystemCredential> findByLoginId(String loginId);
+    Optional<SystemCredential> findByUser(User user);
 }

--- a/backend/src/main/java/com/study/focus/account/repository/UserRepository.java
+++ b/backend/src/main/java/com/study/focus/account/repository/UserRepository.java
@@ -3,5 +3,7 @@ package com.study.focus.account.repository;
 import com.study.focus.account.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
 }

--- a/backend/src/main/java/com/study/focus/account/service/AccountService.java
+++ b/backend/src/main/java/com/study/focus/account/service/AccountService.java
@@ -1,32 +1,121 @@
 package com.study.focus.account.service;
 
+import com.study.focus.account.domain.*;
+import com.study.focus.account.dto.*;
+import com.study.focus.account.repository.OAuthCredentialRepository;
+import com.study.focus.account.repository.RefreshTokenRepository;
+import com.study.focus.account.repository.SystemCredentialRepository;
+import com.study.focus.account.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
+@Transactional
 public class AccountService {
 
+    private final UserRepository userRepository;
+    private final SystemCredentialRepository systemCredentialRepository;
+    private final OAuthCredentialRepository oAuthCredentialRepository;
+    private final TokenService tokenService;
+    private final RefreshTokenService
+            refreshTokenService;
+    private final PasswordEncoder passwordEncoder;
+    private final RefreshTokenRepository refreshTokenRepository;
+
     // OAuth 로그인
-    public void oauthLogin(String provider) {
-        // TODO: OAuth 로그인 처리
+    public LoginResponse oauthLogin(Provider provider, String providerUserId) {
+        // Credential 확인
+        OAuthCredential credential = oAuthCredentialRepository.findByProviderAndProviderUserId(provider, providerUserId)
+                .orElseGet(() -> {
+                    // 신규 사용자 → User 생성
+                    User newUser = User.builder()
+                            .loginType(LoginType.OAUTH)
+                            .build();
+                    userRepository.save(newUser);
+
+                    OAuthCredential newCredential = OAuthCredential.builder()
+                            .provider(provider)
+                            .providerUserId(providerUserId)
+                            .user(newUser)
+                            .build();
+                    return oAuthCredentialRepository.save(newCredential);
+                });
+
+        User user = credential.getUser();
+        user.updateLastLoginAt();
+
+        // identifier: "provider:providerId"
+        String identifier = provider.name() + ":" + providerUserId;
+
+        // JWT 발급
+        TokenResponse tokenResponse = tokenService.createToken(user, identifier);
+
+        // RefreshToken 저장
+        refreshTokenService.saveOrUpdate(user, tokenResponse.getRefreshToken(), tokenResponse.getRefreshTokenExpiry());
+
+        return new LoginResponse(tokenResponse.getAccessToken(), tokenResponse.getRefreshToken());
     }
 
     // 회원가입
-    public void register() {
-        // TODO: 회원가입 처리
+    public void register(RegisterRequest request) {
+        if (systemCredentialRepository.existsByLoginId(request.getLoginId())) {
+            throw new IllegalArgumentException("이미 존재하는 아이디입니다.");
+        }
+
+        // 1. User 생성
+        User user = User.builder()
+                .loginType(LoginType.SYSTEM)
+                .build();
+        userRepository.save(user);
+
+        // 2. SystemCredential 생성 (loginId, password)
+        SystemCredential credential = SystemCredential.builder()
+                .loginId(request.getLoginId())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .user(user)
+                .build();
+        systemCredentialRepository.save(credential);
     }
 
     // 아이디 중복 확인
     public void checkId(String loginId) {
-        // TODO: loginId 중복 확인
+        if (systemCredentialRepository.existsByLoginId(loginId)) {
+            throw new IllegalArgumentException("이미 존재하는 아이디입니다.");
+        }
     }
 
     // 일반 로그인
-    public void login() {
-        // TODO: 일반 로그인 처리
+    public LoginResponse login(LoginRequest request) {
+        SystemCredential credential = systemCredentialRepository.findByLoginId(request.getLoginId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 아이디입니다."));
+
+        if (!passwordEncoder.matches(request.getPassword(), credential.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        User user = credential.getUser();
+        user.updateLastLoginAt();
+
+        String identifier = credential.getLoginId();
+
+        TokenResponse tokenResponse = tokenService.createToken(user, identifier);
+
+        refreshTokenService.saveOrUpdate(user, tokenResponse.getRefreshToken(), tokenResponse.getRefreshTokenExpiry());
+
+        return new LoginResponse(tokenResponse.getAccessToken(), tokenResponse.getRefreshToken());
     }
 
     // 로그아웃
-    public void logout() {
-        // TODO: 로그아웃 처리
+    public void logout(Long userId) {
+        refreshTokenService.deleteByUserId(userId);
+    }
+
+    // 로그아웃
+    public void logoutByRefreshToken(String refreshToken) {
+        refreshTokenRepository.findByToken(refreshToken)
+                .ifPresent(refreshTokenRepository::delete);
     }
 }

--- a/backend/src/main/java/com/study/focus/account/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/study/focus/account/service/RefreshTokenService.java
@@ -1,0 +1,46 @@
+package com.study.focus.account.service;
+
+import com.study.focus.account.domain.RefreshToken;
+import com.study.focus.account.domain.User;
+import com.study.focus.account.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public void saveOrUpdate(User user, String token, Long expiryMillis) {
+        LocalDateTime expiryDate = LocalDateTime.now().plus(Duration.ofMillis(expiryMillis));
+
+        refreshTokenRepository.findByUserId(user.getId())
+                .ifPresentOrElse(
+                        rt -> rt.update(token, expiryDate),
+                        () -> {
+                            RefreshToken newToken = RefreshToken.builder()
+                                    .token(token)
+                                    .expiryDate(expiryDate)
+                                    .user(user)
+                                    .build();
+                            refreshTokenRepository.save(newToken);
+                        }
+                );
+    }
+
+    public RefreshToken findByRefreshToken(String refreshToken) {
+        return refreshTokenRepository.findByToken(refreshToken)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 RefreshToken 입니다."));
+    }
+
+    public void deleteByUserId(Long userId) {
+        User user = User.builder().id(userId).build();
+        refreshTokenRepository.deleteByUser(user);
+    }
+}

--- a/backend/src/main/java/com/study/focus/account/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/study/focus/account/service/RefreshTokenService.java
@@ -40,7 +40,6 @@ public class RefreshTokenService {
     }
 
     public void deleteByUserId(Long userId) {
-        User user = User.builder().id(userId).build();
-        refreshTokenRepository.deleteByUser(user);
+        refreshTokenRepository.deleteByUserId(userId);
     }
 }

--- a/backend/src/main/java/com/study/focus/account/service/TokenService.java
+++ b/backend/src/main/java/com/study/focus/account/service/TokenService.java
@@ -1,0 +1,65 @@
+package com.study.focus.account.service;
+
+import com.study.focus.account.domain.LoginType;
+import com.study.focus.account.domain.OAuthCredential;
+import com.study.focus.account.domain.RefreshToken;
+import com.study.focus.account.domain.User;
+import com.study.focus.account.config.jwt.TokenProvider;
+import com.study.focus.account.dto.TokenResponse;
+import com.study.focus.account.repository.OAuthCredentialRepository;
+import com.study.focus.account.repository.SystemCredentialRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final TokenProvider tokenProvider;
+    private final RefreshTokenService refreshTokenService;
+    private final SystemCredentialRepository  systemCredentialRepository;
+    private final OAuthCredentialRepository oAuthCredentialRepository;
+
+    /**
+     * 토큰 생성 (로그인 시 호출)
+     */
+    public TokenResponse createToken(User user, String identifier) {
+        String accessToken = tokenProvider.createAccessToken(user.getId(), identifier);
+        String refreshToken = tokenProvider.createRefreshToken(user.getId());
+
+        return new TokenResponse(
+                accessToken,
+                refreshToken,
+                tokenProvider.getRefreshTokenExpiry()
+        );
+    }
+
+    /**
+     * RefreshToken 기반 AccessToken 재발급
+     */
+    @Transactional
+    public String createNewAccessToken(String refreshTokenValue) {
+        RefreshToken refreshToken = refreshTokenService.findByRefreshToken(refreshTokenValue);
+
+        if (refreshToken.isExpired()) {
+            throw new IllegalArgumentException("Refresh Token이 만료되었습니다.");
+        }
+
+        User user = refreshToken.getUser();
+
+        // identifier 결정
+        String identifier;
+        if (user.getLoginType() == LoginType.SYSTEM) {
+            identifier = systemCredentialRepository.findByUser(user)
+                    .orElseThrow(() -> new IllegalArgumentException("SystemCredential이 존재하지 않습니다."))
+                    .getLoginId();
+        } else {
+            OAuthCredential credential = oAuthCredentialRepository.findByUser(user)
+                    .orElseThrow(() -> new IllegalArgumentException("OAuthCredential이 존재하지 않습니다."));
+            identifier = credential.getProvider().name() + ":" + credential.getProviderUserId();
+        }
+
+        return tokenProvider.createAccessToken(user.getId(), identifier);
+    }
+}

--- a/backend/src/main/java/com/study/focus/account/service/UserService.java
+++ b/backend/src/main/java/com/study/focus/account/service/UserService.java
@@ -1,9 +1,15 @@
 package com.study.focus.account.service;
 
+import com.study.focus.account.domain.User;
+import com.study.focus.account.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class UserService {
+
+    private final UserRepository userRepository;
 
     // 초기 프로필 설정
     public void createProfile(Long userId) {
@@ -18,5 +24,10 @@ public class UserService {
     // 내 프로필 수정
     public void updateMyProfile(Long userId) {
         // TODO: 내 프로필 수정
+    }
+
+    public User findById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
     }
 }

--- a/backend/src/main/java/com/study/focus/application/domain/Application.java
+++ b/backend/src/main/java/com/study/focus/application/domain/Application.java
@@ -29,6 +29,7 @@ public class Application extends BaseCreatedEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
+    @Builder.Default
     private ApplicationStatus status = SUBMITTED;
 
     @Lob

--- a/backend/src/main/java/com/study/focus/common/util/CookieUtil.java
+++ b/backend/src/main/java/com/study/focus/common/util/CookieUtil.java
@@ -1,0 +1,47 @@
+package com.study.focus.common.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.util.SerializationUtils;
+
+import java.util.Base64;
+
+public class CookieUtil {
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return;
+        }
+
+        for (Cookie cookie : cookies) {
+            if (name.equals(cookie.getName())) {
+                cookie.setValue("");
+                cookie.setPath("/");
+                cookie.setMaxAge(0);
+                response.addCookie(cookie);
+            }
+        }
+    }
+
+    public static String serialize(Object obj) {
+        return Base64.getUrlEncoder()
+                .encodeToString(SerializationUtils.serialize(obj));
+    }
+
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return cls.cast(
+                SerializationUtils.deserialize(
+                        Base64.getUrlDecoder().decode(cookie.getValue())
+                )
+        );
+    }
+}

--- a/backend/src/main/java/com/study/focus/study/domain/Study.java
+++ b/backend/src/main/java/com/study/focus/study/domain/Study.java
@@ -20,5 +20,6 @@ public class Study extends BaseCreatedEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
+    @Builder.Default
     private RecruitStatus recruitStatus = RecruitStatus.OPEN;
 }

--- a/backend/src/main/java/com/study/focus/study/domain/StudyMember.java
+++ b/backend/src/main/java/com/study/focus/study/domain/StudyMember.java
@@ -38,6 +38,7 @@ public class StudyMember extends BaseCreatedEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
+    @Builder.Default
     private StudyMemberStatus status =  JOINED;
 
     @Column(nullable = true)

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -47,14 +47,14 @@ spring:
             client-secret: ${GOOGLE_CLIENT_SECRET}
             client-name: Google
             authorization-grant-type: authorization_code
-            redirect-uri: ${GOOGLE_REDIRECT_URI}
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             scope: email, profile, openid
           naver:
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_CLIENT_SECRET}
             client-name: Naver
             authorization-grant-type: authorization_code
-            redirect-uri: ${NAVER_REDIRECT_URI}
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             scope:
               - nickname
               - email
@@ -65,7 +65,7 @@ spring:
             client-name: Kakao
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
-            redirect-uri: ${KAKAO_REDIRECT_URI}
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             scope:
               - profile_nickname
               - profile_image

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -37,3 +37,53 @@ spring:
       hibernate:
         format_sql: true
     show-sql: true
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            client-name: Google
+            authorization-grant-type: authorization_code
+            redirect-uri: ${GOOGLE_REDIRECT_URI}
+            scope: email, profile, openid
+          naver:
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+            client-name: Naver
+            authorization-grant-type: authorization_code
+            redirect-uri: ${NAVER_REDIRECT_URI}
+            scope:
+              - nickname
+              - email
+              - profile
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            client-name: Kakao
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: ${KAKAO_REDIRECT_URI}
+            scope:
+              - profile_nickname
+              - profile_image
+
+        provider:
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+jwt:
+  secret-key: ${JWT_SECRET_KEY}
+  access-token-expiry: 3600000        # 1시간 (ms)
+  refresh-token-expiry: 1209600000    # 14일 (ms)
+  issuer: guscjf8921@gmail.com

--- a/backend/src/main/resources/static/home.html
+++ b/backend/src/main/resources/static/home.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+	<meta charset="UTF-8">
+	<title>홈</title>
+	<style>
+		body {
+			font-family: Arial, sans-serif;
+			text-align: center;
+			margin-top: 50px;
+		}
+		.token-box {
+			border: 1px solid #ddd;
+			background: #f9f9f9;
+			margin: 20px auto;
+			padding: 15px;
+			width: 80%;
+			max-width: 600px;
+			border-radius: 8px;
+			word-break: break-all;
+			text-align: left;
+		}
+		button {
+			padding: 10px 20px;
+			border: none;
+			border-radius: 5px;
+			background: #d9534f;
+			color: white;
+			cursor: pointer;
+			font-size: 14px;
+			margin-top: 20px;
+		}
+	</style>
+</head>
+<body>
+
+<h1>홈 화면</h1>
+<p>로그인에 성공했습니다 🎉</p>
+
+<div class="token-box">
+	<strong>Access Token:</strong>
+	<p id="accessToken"></p>
+	<strong>User ID (토큰에서 추출):</strong>
+	<p id="userId"></p>
+</div>
+
+<button id="logout-btn">로그아웃</button>
+
+<script>
+	// ✅ 쿼리스트링에서 AccessToken 추출 (OAuth SuccessHandler가 붙여준 값)
+	const params = new URLSearchParams(window.location.search);
+	let accessToken = params.get("token");
+	
+	// ✅ 토큰 갱신 (refresh_token은 서버가 쿠키로 관리하므로 credentials: include 필요)
+	async function refreshAccessToken() {
+		try {
+			const response = await fetch("/api/auth/token", {
+				method: "POST",
+				credentials: "include" // <- 쿠키 포함
+			});
+			
+			if (response.ok) {
+				const data = await response.json();
+				accessToken = data.accessToken;
+				document.getElementById("accessToken").textContent = accessToken;
+				
+				// userId 다시 표시
+				const payload = JSON.parse(atob(accessToken.split(".")[1]));
+				document.getElementById("userId").textContent = payload.sub;
+			} else {
+				alert("토큰 갱신 실패: " + response.status);
+			}
+		} catch (err) {
+			alert("토큰 요청 오류: " + err);
+		}
+	}
+	
+	// ✅ 초기화
+	async function initPage() {
+		if (accessToken) {
+			document.getElementById("accessToken").textContent = accessToken;
+			try {
+				const payload = JSON.parse(atob(accessToken.split(".")[1]));
+				document.getElementById("userId").textContent = payload.sub;
+			} catch (e) {
+				document.getElementById("userId").textContent = "파싱 실패";
+			}
+		} else {
+			// URL에 accessToken 없으면 새로 발급받기
+			await refreshAccessToken();
+		}
+	}
+	initPage();
+	
+	// ✅ 로그아웃
+	document.getElementById("logout-btn").addEventListener("click", async function() {
+		try {
+			const response = await fetch("/api/auth/logout", {
+				method: "POST",
+				credentials: "include" // 쿠키 포함
+			});
+			
+			if (response.ok) {
+				alert("로그아웃 성공!");
+				window.location.href = "/login.html";
+			} else {
+				alert("로그아웃 실패: " + response.status);
+			}
+		} catch (err) {
+			alert("로그아웃 요청 오류: " + err);
+		}
+	});
+</script>
+
+</body>
+</html>

--- a/backend/src/main/resources/static/login.html
+++ b/backend/src/main/resources/static/login.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+	<meta charset="UTF-8">
+	<title>로그인</title>
+	<style>
+		body {
+			font-family: Arial, sans-serif;
+			max-width: 400px;
+			margin: 50px auto;
+		}
+		h1 { text-align: center; }
+		.login-form, .oauth-login, .register-form {
+			border: 1px solid #ddd;
+			padding: 20px;
+			margin-bottom: 20px;
+			border-radius: 8px;
+		}
+		.login-form input, .register-form input {
+			display: block;
+			width: 95%;
+			margin: 10px auto;
+			padding: 10px;
+		}
+		button {
+			display: block;
+			width: 100%;
+			margin: 10px 0;
+			padding: 10px;
+			border: none;
+			border-radius: 5px;
+			font-size: 14px;
+			cursor: pointer;
+		}
+		.google { background: #4285F4; color: white; }
+		.naver { background: #03C75A; color: white; }
+		.kakao { background: #FEE500; color: #3C1E1E; }
+		.error { color: red; font-size: 13px; text-align: center; }
+		.success { color: green; font-size: 13px; text-align: center; }
+	</style>
+</head>
+<body>
+
+<h1>로그인</h1>
+
+<!-- ✅ 시스템 로그인 -->
+<form id="login-form" class="login-form" action="/api/auth/login" method="post">
+	<input type="text" name="loginId" placeholder="아이디" required>
+	<input type="password" name="password" placeholder="비밀번호" required>
+	<button type="submit">로그인</button>
+</form>
+
+<!-- ✅ 회원가입 -->
+<form id="register-form" class="register-form">
+	<input type="text" name="loginId" placeholder="아이디" required>
+	<input type="password" name="password" placeholder="비밀번호" required>
+	<button type="submit">회원가입</button>
+	<p id="register-message"></p>
+</form>
+
+<!-- ✅ OAuth 로그인 -->
+<div class="oauth-login">
+	<p style="text-align:center;">또는 소셜 계정으로 로그인</p>
+	<a href="/oauth2/authorization/google"><button type="button" class="google">Google 로그인</button></a>
+	<a href="/oauth2/authorization/naver"><button type="button" class="naver">Naver 로그인</button></a>
+	<a href="/oauth2/authorization/kakao"><button type="button" class="kakao">Kakao 로그인</button></a>
+</div>
+
+</body>
+</html>
+
+<script>
+	// ✅ 회원가입
+	document.getElementById("register-form").addEventListener("submit", async function(e) {
+		e.preventDefault();
+		const loginId = e.target.loginId.value;
+		const password = e.target.password.value;
+		const messageBox = document.getElementById("register-message");
+		messageBox.textContent = "";
+		
+		try {
+			const response = await fetch("/api/auth/register", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ loginId, password })
+			});
+			
+			if (response.ok) {
+				messageBox.textContent = "회원가입 성공! 이제 로그인하세요.";
+				messageBox.className = "success";
+			} else {
+				const err = await response.json();
+				messageBox.textContent = "회원가입 실패: " + (err.message || response.status);
+				messageBox.className = "error";
+			}
+		} catch (err) {
+			messageBox.textContent = "회원가입 요청 중 오류 발생: " + err;
+			messageBox.className = "error";
+		}
+	});
+</script>

--- a/backend/src/test/java/com/study/focus/account/config/jwt/JwtFactory.java
+++ b/backend/src/test/java/com/study/focus/account/config/jwt/JwtFactory.java
@@ -1,0 +1,54 @@
+package com.study.focus.account.config.jwt;
+
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.security.Key;
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+
+@Getter
+public class JwtFactory {
+
+    private String subject = "1"; // 기본값: userId = 1
+    private Date issuedAt = new Date();
+    private Date expiration = new Date(new Date().getTime() + Duration.ofDays(14).toMillis());
+    private Map<String, Object> claims = emptyMap();
+
+    @Builder
+    public JwtFactory(String subject, Date issuedAt, Date expiration,
+                      Map<String ,Object> claims) {
+        this.subject = (subject != null) ? subject : this.subject;
+        this.issuedAt = (issuedAt != null) ? issuedAt : this.issuedAt;
+        this.expiration = (expiration != null) ? expiration : this.expiration;
+        this.claims = (claims != null) ? claims : this.claims;
+    }
+
+    public static JwtFactory withDefaultValues() {
+        return JwtFactory.builder().build();
+    }
+
+    public String createToken(JwtProperties jwtProperties) {
+        // HS256 서명 키 준비
+        byte[] keyBytes = Decoders.BASE64.decode(jwtProperties.getSecretKey());
+        Key key = Keys.hmacShaKeyFor(keyBytes);
+
+        return Jwts.builder()
+                .setSubject(subject) // userId 같은 값
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setIssuer(jwtProperties.getIssuer())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiration)
+                .addClaims(claims)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+}

--- a/backend/src/test/java/com/study/focus/account/config/jwt/JwtFactory.java
+++ b/backend/src/test/java/com/study/focus/account/config/jwt/JwtFactory.java
@@ -25,7 +25,7 @@ public class JwtFactory {
 
     @Builder
     public JwtFactory(String subject, Date issuedAt, Date expiration,
-                      Map<String ,Object> claims) {
+                      Map<String, Object> claims) {
         this.subject = (subject != null) ? subject : this.subject;
         this.issuedAt = (issuedAt != null) ? issuedAt : this.issuedAt;
         this.expiration = (expiration != null) ? expiration : this.expiration;

--- a/backend/src/test/java/com/study/focus/account/config/jwt/TokenProviderTest.java
+++ b/backend/src/test/java/com/study/focus/account/config/jwt/TokenProviderTest.java
@@ -1,0 +1,158 @@
+package com.study.focus.account.config.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+class TokenProviderTest {
+
+    private TokenProvider tokenProvider;
+    private JwtProperties jwtProperties;
+
+    @BeforeEach
+    void setUp() {
+        jwtProperties = new JwtProperties();
+        // application.yml 설정값 그대로 사용
+        jwtProperties.setSecretKey("A4wZcrvhI3eV3YWa4auKBMUCx7ZHTpl0mTL2ngtoNHI=");
+        jwtProperties.setIssuer("guscjf8921@gmail.com");
+        jwtProperties.setAccessTokenExpiry(3600000L);       // 1시간
+        jwtProperties.setRefreshTokenExpiry(1209600000L);   // 14일
+
+        tokenProvider = new TokenProvider(jwtProperties);
+        tokenProvider.init(); // @PostConstruct 수동 호출
+    }
+
+    @Test
+    @DisplayName("AccessToken을 생성하고 유저아이디와 identifier를 추출할 수 있다")
+    void createAccessTokenAndExtractUserId() {
+        // given
+        Long userId = 123L;
+        String identifier = "system";
+
+        // when
+        String accessToken = tokenProvider.createAccessToken(userId, identifier);
+        Long extractedUserId = tokenProvider.getUserIdFromToken(accessToken);
+        Claims claims = tokenProvider.getClaims(accessToken);
+
+        // then
+        assertThat(extractedUserId).isEqualTo(userId);
+        assertThat(claims.get("identifier", String.class)).isEqualTo(identifier);
+        assertThat(claims.getSubject()).isEqualTo(userId.toString());
+    }
+
+    @Test
+    @DisplayName("RefreshToken을 생성하고 유저아이디를 추출할 수 있다")
+    void createRefreshTokenAndExtractUserId() {
+        // given
+        Long userId = 456L;
+
+        // when
+        String refreshToken = tokenProvider.createRefreshToken(userId);
+        Long extractedUserId = tokenProvider.getUserIdFromToken(refreshToken);
+
+        // then
+        assertThat(extractedUserId).isEqualTo(userId);
+        assertThat(tokenProvider.validateToken(refreshToken)).isTrue();
+    }
+
+    @Test
+    @DisplayName("JwtFactory로 생성한 토큰에서 subject를 읽을 수 있다")
+    void createTokenWithJwtFactory() {
+        // given
+        JwtFactory jwtFactory = JwtFactory.builder()
+                .subject("789") // subject는 String
+                .build();
+
+        // when
+        String token = jwtFactory.createToken(jwtProperties);
+        Claims claims = tokenProvider.getClaims(token);
+
+        // then
+        assertThat(claims.getSubject()).isEqualTo("789");
+    }
+
+    @Test
+    @DisplayName("잘못된 토큰은 validateToken이 false를 반환한다")
+    void invalidTokenShouldReturnFalse() {
+        // given
+        String invalidToken = "this.is.not.a.valid.token";
+
+        // when
+        boolean result = tokenProvider.validateToken(invalidToken);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("AccessToken 만료시간이 설정대로 반영된다")
+    void accessTokenExpiryIsAppliedCorrectly() {
+        // given
+        Long userId = 999L;
+        String identifier = "expiry-test";
+
+        // when
+        String token = tokenProvider.createAccessToken(userId, identifier);
+        Claims claims = tokenProvider.getClaims(token);
+
+        long expectedExpiryMillis = jwtProperties.getAccessTokenExpiry();
+        long actualExpiryMillis = claims.getExpiration().getTime() - claims.getIssuedAt().getTime();
+
+        // then
+        assertThat(actualExpiryMillis).isEqualTo(expectedExpiryMillis);
+    }
+
+    @Test
+    @DisplayName("RefreshToken 만료시간이 설정대로 반영된다")
+    void refreshTokenExpiryIsAppliedCorrectly() {
+        // given
+        Long userId = 1000L;
+
+        // when
+        String token = tokenProvider.createRefreshToken(userId);
+        Claims claims = tokenProvider.getClaims(token);
+
+        long expectedExpiryMillis = jwtProperties.getRefreshTokenExpiry();
+        long actualExpiryMillis = claims.getExpiration().getTime() - claims.getIssuedAt().getTime();
+
+        // then
+        assertThat(actualExpiryMillis).isEqualTo(expectedExpiryMillis);
+    }
+
+    @Test
+    @DisplayName("토큰의 issuer 값은 설정한 issuer와 동일해야 한다")
+    void tokenIssuerShouldMatch() {
+        // given
+        String token = tokenProvider.createAccessToken(999L, "issuer-test");
+
+        // when
+        Claims claims = tokenProvider.getClaims(token);
+
+        // then
+        assertThat(claims.getIssuer()).isEqualTo(jwtProperties.getIssuer());
+    }
+
+    @Test
+    @DisplayName("만료된 토큰은 validateToken이 false를 반환하고 getClaims는 예외를 발생시킨다")
+    void expiredTokenShouldBeInvalid() {
+        // given: 만료시간을 과거로 설정
+        JwtFactory jwtFactory = JwtFactory.builder()
+                .subject("111")
+                .expiration(new Date(System.currentTimeMillis() - 1000)) // 이미 만료
+                .build();
+
+        String expiredToken = jwtFactory.createToken(jwtProperties);
+
+        // when & then
+        assertThat(tokenProvider.validateToken(expiredToken)).isFalse();
+        assertThatThrownBy(() -> tokenProvider.getClaims(expiredToken))
+                .isInstanceOf(ExpiredJwtException.class);
+    }
+}

--- a/backend/src/test/java/com/study/focus/account/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/study/focus/account/controller/AuthControllerTest.java
@@ -1,0 +1,73 @@
+package com.study.focus.account.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.study.focus.account.domain.Provider;
+import com.study.focus.account.dto.LoginResponse;
+import com.study.focus.account.dto.RegisterRequest;
+import com.study.focus.account.service.AccountService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+// 👇 JPA Auditing에서 필요한 Context를 Mock으로 대체
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+        controllers = AuthController.class,
+        excludeAutoConfiguration = {
+                org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration.class
+        }
+)
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AccountService accountService;
+
+    // 👇 추가: JPA MappingContext를 Mock 처리 (Auditing 때문에 필요)
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @Test
+    @DisplayName("회원가입 성공")
+    void register_success() throws Exception {
+        RegisterRequest request = new RegisterRequest("id", "pw");
+        doNothing().when(accountService).register(any());
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("OAuth 로그인 콜백 성공")
+    void oauthCallback_success() throws Exception {
+        when(accountService.oauthLogin(Provider.GOOGLE, "123"))
+                .thenReturn(new LoginResponse("access", "refresh"));
+
+        mockMvc.perform(post("/api/auth/oauth/callback")
+                        .param("provider", "google")
+                        .param("providerUserId", "123"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("access"))
+                .andExpect(jsonPath("$.refreshToken").value("refresh"));
+    }
+}

--- a/backend/src/test/java/com/study/focus/account/controller/TokenApiControllerTest.java
+++ b/backend/src/test/java/com/study/focus/account/controller/TokenApiControllerTest.java
@@ -1,0 +1,56 @@
+package com.study.focus.account.controller;
+
+import com.study.focus.account.service.TokenService;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(TokenApiController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class TokenApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TokenService tokenService;
+
+    // ✅ JPA 관련 빈 목 처리 (JPA metamodel must not be empty 오류 방지)
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @Test
+    @DisplayName("refresh_token 쿠키를 통해 새로운 access token을 발급한다")
+    void createNewAccessToken() throws Exception {
+        // given
+        String refreshToken = "refresh-token-sample";
+        String newAccessToken = "new-access-token";
+
+        given(tokenService.createNewAccessToken(refreshToken))
+                .willReturn(newAccessToken);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/token")
+                        .cookie(new Cookie("refresh_token", refreshToken))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.accessToken").value(newAccessToken));
+
+        // verify
+        verify(tokenService).createNewAccessToken(refreshToken);
+    }
+}

--- a/backend/src/test/java/com/study/focus/account/service/AccountServiceTest.java
+++ b/backend/src/test/java/com/study/focus/account/service/AccountServiceTest.java
@@ -1,0 +1,183 @@
+package com.study.focus.account.service;
+
+import com.study.focus.account.domain.*;
+import com.study.focus.account.dto.LoginRequest;
+import com.study.focus.account.dto.LoginResponse;
+import com.study.focus.account.dto.RegisterRequest;
+import com.study.focus.account.dto.TokenResponse;
+import com.study.focus.account.repository.OAuthCredentialRepository;
+import com.study.focus.account.repository.RefreshTokenRepository;
+import com.study.focus.account.repository.SystemCredentialRepository;
+import com.study.focus.account.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class AccountServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private SystemCredentialRepository systemCredentialRepository;
+    @Mock private OAuthCredentialRepository oAuthCredentialRepository;
+    @Mock private TokenService tokenService;
+    @Mock private RefreshTokenService refreshTokenService;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks
+    private AccountService accountService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("시스템 로그인 성공 - 올바른 아이디/비밀번호")
+    void login_success() {
+        // given
+        User user = User.builder().id(1L).loginType(LoginType.SYSTEM).build();
+        SystemCredential credential = SystemCredential.builder()
+                .user(user)
+                .loginId("testId")
+                .password("encodedPw")
+                .build();
+
+        when(systemCredentialRepository.findByLoginId("testId"))
+                .thenReturn(Optional.of(credential));
+        when(passwordEncoder.matches("rawPw", "encodedPw")).thenReturn(true);
+        when(tokenService.createToken(any(), any()))
+                .thenReturn(new TokenResponse("access", "refresh", 1000L));
+
+        // when
+        LoginResponse response = accountService.login(
+                new LoginRequest("testId", "rawPw")
+        );
+
+        // then
+        assertThat(response.getAccessToken()).isEqualTo("access");
+        assertThat(response.getRefreshToken()).isEqualTo("refresh");
+        verify(refreshTokenService).saveOrUpdate(eq(user), eq("refresh"), any());
+    }
+
+    @Test
+    @DisplayName("시스템 로그인 실패 - 아이디 없음")
+    void login_fail_notFound() {
+        when(systemCredentialRepository.findByLoginId("wrongId"))
+                .thenReturn(Optional.empty());
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> accountService.login(new LoginRequest("wrongId", "pw"))
+        );
+
+        assertThat(ex.getMessage()).isEqualTo("존재하지 않는 아이디입니다.");
+    }
+
+    @Test
+    @DisplayName("시스템 로그인 실패 - 비밀번호 불일치")
+    void login_fail_invalidPassword() {
+        User user = User.builder().id(1L).build();
+        SystemCredential credential = SystemCredential.builder()
+                .user(user)
+                .loginId("id")
+                .password("encodedPw")
+                .build();
+
+        when(systemCredentialRepository.findByLoginId("id"))
+                .thenReturn(Optional.of(credential));
+        when(passwordEncoder.matches("wrongPw", "encodedPw")).thenReturn(false);
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> accountService.login(new LoginRequest("id", "wrongPw"))
+        );
+
+        assertThat(ex.getMessage()).isEqualTo("비밀번호가 일치하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 중복 아이디")
+    void register_fail_duplicateId() {
+        when(systemCredentialRepository.existsByLoginId("dupId")).thenReturn(true);
+
+        RegisterRequest request = new RegisterRequest("dupId", "pw");
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> accountService.register(request)
+        );
+
+        assertThat(ex.getMessage()).isEqualTo("이미 존재하는 아이디입니다.");
+    }
+
+    @Test
+    @DisplayName("OAuth 로그인 신규 유저 생성")
+    void oauthLogin_newUser() {
+        when(oAuthCredentialRepository.findByProviderAndProviderUserId(Provider.GOOGLE, "123"))
+                .thenReturn(Optional.empty());
+
+        User newUser = User.builder().id(1L).loginType(LoginType.OAUTH).build();
+        OAuthCredential newCred = OAuthCredential.builder()
+                .id(10L)
+                .user(newUser)
+                .provider(Provider.GOOGLE)
+                .providerUserId("123")
+                .build();
+
+        when(userRepository.save(any(User.class))).thenReturn(newUser);
+        when(oAuthCredentialRepository.save(any(OAuthCredential.class))).thenReturn(newCred);
+        when(tokenService.createToken(any(), any()))
+                .thenReturn(new TokenResponse("access", "refresh", 1000L));
+
+        LoginResponse response = accountService.oauthLogin(Provider.GOOGLE, "123");
+
+        assertThat(response.getAccessToken()).isEqualTo("access");
+        assertThat(response.getRefreshToken()).isEqualTo("refresh");
+        verify(refreshTokenService).saveOrUpdate(eq(newUser), eq("refresh"), any());
+    }
+
+    @Test
+    @DisplayName("logout(userId) 호출 시 RefreshTokenService.deleteByUserId 실행")
+    void logout_byUserId() {
+        Long userId = 100L;
+
+        // when
+        accountService.logout(userId);
+
+        // then
+        verify(refreshTokenService, times(1)).deleteByUserId(userId);
+    }
+
+    @Test
+    @DisplayName("logoutByRefreshToken(refreshToken) - 토큰 존재하면 삭제")
+    void logoutByRefreshToken_found() {
+        RefreshToken rt = mock(RefreshToken.class);
+        when(refreshTokenRepository.findByToken("validRefresh"))
+                .thenReturn(Optional.of(rt));
+
+        accountService.logoutByRefreshToken("validRefresh");
+
+        verify(refreshTokenRepository, times(1)).delete(rt);
+    }
+
+    @Test
+    @DisplayName("logoutByRefreshToken(refreshToken) - 토큰 없으면 아무 일도 없음")
+    void logoutByRefreshToken_notFound() {
+        when(refreshTokenRepository.findByToken("missingRefresh"))
+                .thenReturn(Optional.empty());
+
+        accountService.logoutByRefreshToken("missingRefresh");
+
+        verify(refreshTokenRepository, never()).delete(any());
+    }
+}

--- a/backend/src/test/java/com/study/focus/account/service/RefreshTokenServiceTest.java
+++ b/backend/src/test/java/com/study/focus/account/service/RefreshTokenServiceTest.java
@@ -1,0 +1,56 @@
+package com.study.focus.account.service;
+
+import com.study.focus.account.domain.RefreshToken;
+import com.study.focus.account.domain.User;
+import com.study.focus.account.repository.RefreshTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+class RefreshTokenServiceTest {
+
+    @Mock private RefreshTokenRepository refreshTokenRepository;
+    @InjectMocks private RefreshTokenService refreshTokenService;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        user = User.builder().id(1L).build();
+    }
+
+    @Test
+    @DisplayName("RefreshToken 저장 및 업데이트")
+    void saveOrUpdate_newAndUpdate() {
+        when(refreshTokenRepository.findByUserId(1L))
+                .thenReturn(Optional.empty());
+
+        refreshTokenService.saveOrUpdate(user, "token123", 1000L);
+
+        verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("RefreshToken 조회 실패 - 잘못된 토큰")
+    void findByRefreshToken_fail() {
+        when(refreshTokenRepository.findByToken("wrong")).thenReturn(Optional.empty());
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> refreshTokenService.findByRefreshToken("wrong")
+        );
+
+        assertThat(ex.getMessage()).isEqualTo("유효하지 않은 RefreshToken 입니다.");
+    }
+}

--- a/backend/src/test/java/com/study/focus/account/service/TokenServiceTest.java
+++ b/backend/src/test/java/com/study/focus/account/service/TokenServiceTest.java
@@ -1,0 +1,139 @@
+package com.study.focus.account.service;
+
+import com.study.focus.account.config.jwt.TokenProvider;
+import com.study.focus.account.domain.*;
+import com.study.focus.account.repository.OAuthCredentialRepository;
+import com.study.focus.account.repository.SystemCredentialRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class TokenServiceTest {
+
+    @Mock private TokenProvider tokenProvider;
+    @Mock private RefreshTokenService refreshTokenService;
+    @Mock private SystemCredentialRepository systemCredentialRepository;
+    @Mock private OAuthCredentialRepository oAuthCredentialRepository;
+
+    @InjectMocks
+    private TokenService tokenService;
+
+    private User systemUser;
+    private User oauthUser;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        systemUser = User.builder()
+                .id(1L)
+                .loginType(LoginType.SYSTEM)
+                .build();
+
+        oauthUser = User.builder()
+                .id(2L)
+                .loginType(LoginType.OAUTH)
+                .build();
+    }
+
+    @Test
+    @DisplayName("토큰 생성 성공")
+    void createToken_success() {
+        when(tokenProvider.createAccessToken(1L, "identifier"))
+                .thenReturn("access123");
+        when(tokenProvider.createRefreshToken(1L))
+                .thenReturn("refresh123");
+        when(tokenProvider.getRefreshTokenExpiry()).thenReturn(3600000L);
+
+        var response = tokenService.createToken(systemUser, "identifier");
+
+        assertThat(response.getAccessToken()).isEqualTo("access123");
+        assertThat(response.getRefreshToken()).isEqualTo("refresh123");
+        assertThat(response.getRefreshTokenExpiry()).isEqualTo(3600000L);
+    }
+
+    @Test
+    @DisplayName("SYSTEM 유저 - RefreshToken 기반 AccessToken 재발급")
+    void createNewAccessToken_systemUser() {
+        RefreshToken refreshToken = RefreshToken.builder()
+                .token("refresh123")
+                .expiryDate(LocalDateTime.now().plusMinutes(30))
+                .user(systemUser)
+                .build();
+
+        SystemCredential credential = SystemCredential.builder()
+                .loginId("sysId")
+                .password("encodedPw")
+                .user(systemUser)
+                .build();
+
+        when(refreshTokenService.findByRefreshToken("refresh123"))
+                .thenReturn(refreshToken);
+        when(systemCredentialRepository.findByUser(systemUser))
+                .thenReturn(Optional.of(credential));
+        when(tokenProvider.createAccessToken(1L, "sysId"))
+                .thenReturn("newAccess123");
+
+        String newAccessToken = tokenService.createNewAccessToken("refresh123");
+
+        assertThat(newAccessToken).isEqualTo("newAccess123");
+    }
+
+    @Test
+    @DisplayName("OAUTH 유저 - RefreshToken 기반 AccessToken 재발급")
+    void createNewAccessToken_oauthUser() {
+        RefreshToken refreshToken = RefreshToken.builder()
+                .token("refresh456")
+                .expiryDate(LocalDateTime.now().plusMinutes(30))
+                .user(oauthUser)
+                .build();
+
+        OAuthCredential credential = OAuthCredential.builder()
+                .provider(Provider.GOOGLE)
+                .providerUserId("google123")
+                .user(oauthUser)
+                .build();
+
+        when(refreshTokenService.findByRefreshToken("refresh456"))
+                .thenReturn(refreshToken);
+        when(oAuthCredentialRepository.findByUser(oauthUser))
+                .thenReturn(Optional.of(credential));
+        when(tokenProvider.createAccessToken(2L, "GOOGLE:google123"))
+                .thenReturn("newAccess456");
+
+        String newAccessToken = tokenService.createNewAccessToken("refresh456");
+
+        assertThat(newAccessToken).isEqualTo("newAccess456");
+    }
+
+    @Test
+    @DisplayName("RefreshToken 만료 - 예외 발생")
+    void createNewAccessToken_expiredToken() {
+        RefreshToken expired = RefreshToken.builder()
+                .token("expired")
+                .expiryDate(LocalDateTime.now().minusMinutes(1))
+                .user(systemUser)
+                .build();
+
+        when(refreshTokenService.findByRefreshToken("expired"))
+                .thenReturn(expired);
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> tokenService.createNewAccessToken("expired")
+        );
+
+        assertThat(ex.getMessage()).isEqualTo("Refresh Token이 만료되었습니다.");
+    }
+}


### PR DESCRIPTION
- RefreshToken 플로우 추가
- Cookie 유틸 및 Security 설정 추가
- 도메인 필드 수정 (user, loginType, refreshToken)
- build.gradle 의존성 추가
- application.yml 파일 OAuth발급키 및 jwt키 환경변수 설정
- docker-compose 포트 충돌 해결
- 테스트 코드 작성 (TokenProvider, TokenApiController, AccountService, TokenService, RefreshTokenService, AuthController)
- 로컬 실행용 HTML 및 PageController 추가 
(localhost:8080/login 에서 로그인, localhost:8080/home에서 토큰값 확인 및 로그아웃을 시험할 수 있게 임시로 작성했습니다.)

.env 파일에 추가사항이 있습니다.
