### PR TITLE
feat: 불필요한 코드 제거,  프로필 이미지 관련 코드 수정 및 삭제

### DIFF
--- a/backend/src/main/java/com/study/focus/account/controller/AuthController.java
+++ b/backend/src/main/java/com/study/focus/account/controller/AuthController.java
@@ -23,19 +23,6 @@ public class AuthController {
 
     // OAuth 로그인 -> OAuth2SuccessHandler 확인
 
-    // ✅ 프론트 연동용 OAuth 로그인 콜백 (JSON 응답)
-    @PostMapping("/oauth/callback")
-    public ResponseEntity<LoginResponse> oauthCallback(
-            @RequestParam("provider") String provider,
-            @RequestParam("providerUserId") String providerUserId) {
-
-        Provider enumProvider = Provider.valueOf(provider.toUpperCase());
-
-        LoginResponse loginResponse = accountService.oauthLogin(enumProvider, providerUserId);
-
-        return ResponseEntity.ok(loginResponse);
-    }
-
     // 회원가입
     @PostMapping("/register")
     public ResponseEntity<Void> register(@RequestBody RegisterRequest request) {
@@ -45,9 +32,9 @@ public class AuthController {
 
     // 아이디 중복 확인
     @GetMapping("/check-id")
-    public ResponseEntity<IdCheckResponse> checkId(@RequestParam String loginId) {
+    public ResponseEntity<CheckDuplicatedIdResponse> checkId(@RequestParam String loginId) {
         boolean available = accountService.checkId(loginId);
-        return ResponseEntity.ok(new IdCheckResponse(available));
+        return ResponseEntity.ok(new CheckDuplicatedIdResponse(available));
     }
 
     // 일반 로그인

--- a/backend/src/main/java/com/study/focus/account/domain/UserProfile.java
+++ b/backend/src/main/java/com/study/focus/account/domain/UserProfile.java
@@ -3,6 +3,7 @@ package com.study.focus.account.domain;
 import com.study.focus.common.domain.Address;
 import com.study.focus.common.domain.BaseUpdatedEntity;
 import com.study.focus.common.domain.Category;
+import com.study.focus.common.domain.File;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -40,7 +41,18 @@ public class UserProfile extends BaseUpdatedEntity {
     @Column(nullable = false)
     private Category preferredCategory;
 
-    @Column(nullable = false, length = 512)
-    @Builder.Default
-    private String profileImageUrl = "https://example.com/default_profile.png";
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "profile_image_id")
+    private File profileImage;
+
+    /**
+     * 프로필 이미지 교체
+     * 기존 파일이 있으면 soft delete 처리 후 새로운 파일로 교체
+     */
+    public void updateProfileImage(File newFile) {
+        if (this.profileImage != null) {
+            this.profileImage.delete(); // isDeleted = true
+        }
+        this.profileImage = newFile;
+    }
 }

--- a/backend/src/main/java/com/study/focus/account/dto/CheckDuplicatedIdResponse.java
+++ b/backend/src/main/java/com/study/focus/account/dto/CheckDuplicatedIdResponse.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class IdCheckResponse {
+public class CheckDuplicatedIdResponse {
     private boolean available;
 }

--- a/backend/src/main/java/com/study/focus/common/domain/File.java
+++ b/backend/src/main/java/com/study/focus/common/domain/File.java
@@ -63,11 +63,14 @@ public class File extends BaseCreatedEntity {
     @JoinColumn(name = "submission_id")
     private Submission submission;
 
+    public void delete() {
+        isDeleted = true;
+    }
+
     public void deleteAnnouncementFile() {
         isDeleted = true;
         announcement = null;
     }
-
 
     public static File ofResource(Resource resource,
                                   FileDetailDto fileDetail) {

--- a/backend/src/test/java/com/study/focus/account/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/study/focus/account/controller/AuthControllerTest.java
@@ -56,18 +56,4 @@ class AuthControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
     }
-
-    @Test
-    @DisplayName("OAuth 로그인 콜백 성공")
-    void oauthCallback_success() throws Exception {
-        when(accountService.oauthLogin(Provider.GOOGLE, "123"))
-                .thenReturn(new LoginResponse("access", "refresh"));
-
-        mockMvc.perform(post("/api/auth/oauth/callback")
-                        .param("provider", "google")
-                        .param("providerUserId", "123"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.accessToken").value("access"))
-                .andExpect(jsonPath("$.refreshToken").value("refresh"));
-    }
 }


### PR DESCRIPTION
- OAuth callback 메서드 제거
- 유저 프로필 이미지 로직 변경
   - public URL -> private bucket의 presigned URL이용
   - 파일엔티티를 참조하도록 변경 및 삭제 메서드 추가(소프트삭제)
- 그룹 프로필 이미지 삭제