### PR TITLE
feat: 유저 프로필 기능 개발 및 공통 예외처리 적용

### DIFF
--- a/backend/src/main/java/com/study/focus/account/config/TokenAuthenticationFilter.java
+++ b/backend/src/main/java/com/study/focus/account/config/TokenAuthenticationFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -17,6 +18,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Slf4j
 @RequiredArgsConstructor
 public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
@@ -54,7 +56,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
             } catch (Exception e) {
                 // 토큰은 유효했지만, 사용자 정보 로드에 실패한 경우
-                System.out.println("토큰은 유효하나 사용자 정보 로드 실패: " + e.getMessage());
+                log.warn("토큰은 유효하나 사용자 정보 로드 실패: {}", e.getMessage());
                 // SecurityContext에 Authentication을 설정하지 않고 넘어가면,
                 // 다음 필터에서 UNAUTHORIZED 처리가 되거나, 컨트롤러에서 null 주입됨.
             }

--- a/backend/src/main/java/com/study/focus/account/config/oauth/OAuth2UserCustomService.java
+++ b/backend/src/main/java/com/study/focus/account/config/oauth/OAuth2UserCustomService.java
@@ -6,11 +6,12 @@ import com.study.focus.account.domain.Provider;
 import com.study.focus.account.domain.User;
 import com.study.focus.account.repository.OAuthCredentialRepository;
 import com.study.focus.account.repository.UserRepository;
-import com.study.focus.account.service.RefreshTokenService;
-import com.study.focus.account.service.TokenService;
+import com.study.focus.common.exception.BusinessException;
+import com.study.focus.common.exception.UserErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,16 +30,13 @@ public class OAuth2UserCustomService extends DefaultOAuth2UserService {
     public OAuth2User loadUser(OAuth2UserRequest userRequest) {
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
-        String registrationId = userRequest.getClientRegistration().getRegistrationId(); // google, kakao, naver
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
         Provider provider = Provider.valueOf(registrationId.toUpperCase());
 
-        // providerId 추출 (각 provider별로 다름)
         String providerUserId = extractProviderId(provider, oAuth2User.getAttributes());
 
-        // Credential 확인
         OAuthCredential credential = oAuthCredentialRepository.findByProviderAndProviderUserId(provider, providerUserId)
                 .orElseGet(() -> {
-                    // 신규 사용자 → User 생성
                     User newUser = User.builder()
                             .loginType(LoginType.OAUTH)
                             .build();
@@ -55,16 +53,15 @@ public class OAuth2UserCustomService extends DefaultOAuth2UserService {
         User user = credential.getUser();
         user.updateLastLoginAt();
 
-        // 여기서는 단순히 UserId만 CustomOAuth2User로 넘김
         return new CustomOAuth2User(user.getId(), oAuth2User.getAttributes(), null);
     }
 
     private String extractProviderId(Provider provider, Map<String, Object> attributes) {
         return switch (provider) {
             case GOOGLE -> (String) attributes.get("sub");
-            case KAKAO -> String.valueOf(attributes.get("id")); // Long → String 변환
+            case KAKAO -> String.valueOf(attributes.get("id"));
             case NAVER -> ((Map<String, Object>) attributes.get("response")).get("id").toString();
-            default -> throw new IllegalArgumentException("지원하지 않는 OAuth Provider입니다: " + provider);
+            default -> throw new BusinessException(UserErrorCode.UNSUPPORTED_PROVIDER);
         };
     }
 }

--- a/backend/src/main/java/com/study/focus/account/controller/UserController.java
+++ b/backend/src/main/java/com/study/focus/account/controller/UserController.java
@@ -1,7 +1,8 @@
 package com.study.focus.account.controller;
 
+import com.study.focus.account.dto.CustomUserDetails;
 import com.study.focus.account.dto.GetMyProfileResponse;
-import com.study.focus.account.dto.InitProfileRequest;
+import com.study.focus.account.dto.InitUserProfileRequest;
 import com.study.focus.account.dto.UpdateUserProfileRequest;
 import com.study.focus.account.service.UserService;
 import jakarta.validation.Valid;
@@ -22,35 +23,35 @@ public class UserController {
     // 초기 프로필 설정 (이미지 제외)
     @PostMapping("/basic")
     public ResponseEntity<Void> initProfile(
-            @AuthenticationPrincipal Long userId,
-            @RequestBody @Valid InitProfileRequest request) {
-        userService.initProfile(userId, request);
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody @Valid InitUserProfileRequest request) {
+        userService.initProfile(user.getUserId(), request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     // 프로필 이미지 설정 (등록/변경)
     @PostMapping("/image")
     public ResponseEntity<String> uploadProfileImage(
-            @AuthenticationPrincipal Long userId,
+            @AuthenticationPrincipal CustomUserDetails user,
             @RequestPart("file") MultipartFile file) {
-        String imageUrl = userService.setProfileImage(userId, file);
+        String imageUrl = userService.setProfileImage(user.getUserId(), file);
         return ResponseEntity.ok(imageUrl);
     }
 
     // 내 프로필 수정 (이미지 제외)
     @PatchMapping
     public ResponseEntity<Void> updateProfile(
-            @AuthenticationPrincipal Long userId,
+            @AuthenticationPrincipal CustomUserDetails user,
             @RequestBody UpdateUserProfileRequest request) {
-        userService.updateProfile(userId, request);
+        userService.updateProfile(user.getUserId(), request);
         return ResponseEntity.ok().build();
     }
 
     // 내 프로필 정보 가져오기
     @GetMapping
     public ResponseEntity<GetMyProfileResponse> getMyProfile(
-            @AuthenticationPrincipal Long userId) {
-        GetMyProfileResponse response = userService.getMyProfile(userId);
+            @AuthenticationPrincipal CustomUserDetails user) {
+        GetMyProfileResponse response = userService.getMyProfile(user.getUserId());
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/study/focus/account/controller/UserController.java
+++ b/backend/src/main/java/com/study/focus/account/controller/UserController.java
@@ -1,20 +1,56 @@
 package com.study.focus.account.controller;
 
+import com.study.focus.account.dto.GetMyProfileResponse;
+import com.study.focus.account.dto.InitProfileRequest;
+import com.study.focus.account.dto.UpdateUserProfileRequest;
+import com.study.focus.account.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/users/me/profile")
+@RequiredArgsConstructor
 public class UserController {
 
-    // 초기 프로필 설정
-    @PostMapping
-    public void createProfile() {}
+    private final UserService userService;
 
-    // 내 프로필 조회
+    // 초기 프로필 설정 (이미지 제외)
+    @PostMapping("/basic")
+    public ResponseEntity<Void> initProfile(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody @Valid InitProfileRequest request) {
+        userService.initProfile(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    // 프로필 이미지 설정 (등록/변경)
+    @PostMapping("/image")
+    public ResponseEntity<String> uploadProfileImage(
+            @AuthenticationPrincipal Long userId,
+            @RequestPart("file") MultipartFile file) {
+        String imageUrl = userService.setProfileImage(userId, file);
+        return ResponseEntity.ok(imageUrl);
+    }
+
+    // 내 프로필 수정 (이미지 제외)
+    @PatchMapping
+    public ResponseEntity<Void> updateProfile(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody UpdateUserProfileRequest request) {
+        userService.updateProfile(userId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    // 내 프로필 정보 가져오기
     @GetMapping
-    public void getMyProfile() {}
-
-    // 내 프로필 수정
-    @PutMapping
-    public void updateMyProfile() {}
+    public ResponseEntity<GetMyProfileResponse> getMyProfile(
+            @AuthenticationPrincipal Long userId) {
+        GetMyProfileResponse response = userService.getMyProfile(userId);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/backend/src/main/java/com/study/focus/account/domain/UserProfile.java
+++ b/backend/src/main/java/com/study/focus/account/domain/UserProfile.java
@@ -20,7 +20,7 @@ public class UserProfile extends BaseUpdatedEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY,  cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User user;
 
@@ -46,13 +46,48 @@ public class UserProfile extends BaseUpdatedEntity {
     private File profileImage;
 
     /**
+     * 초기 프로필 생성
+     */
+    public static UserProfile create(User user,
+                                     String nickname,
+                                     Address address,
+                                     LocalDate birthDate,
+                                     Job job,
+                                     Category preferredCategory) {
+        return UserProfile.builder()
+                .user(user)
+                .nickname(nickname)
+                .address(address)
+                .birthDate(birthDate)
+                .job(job)
+                .preferredCategory(preferredCategory)
+                .build();
+    }
+
+    /**
+     * 프로필 수정
+     */
+    public void updateProfile(String nickname,
+                              Address address,
+                              LocalDate birthDate,
+                              Job job,
+                              Category preferredCategory) {
+        this.nickname = nickname;
+        this.address = address;
+        this.birthDate = birthDate;
+        this.job = job;
+        this.preferredCategory = preferredCategory;
+    }
+
+    /**
      * 프로필 이미지 교체
-     * 기존 파일이 있으면 soft delete 처리 후 새로운 파일로 교체
+     * 기존 파일이 있으면 soft delete 후 교체
      */
     public void updateProfileImage(File newFile) {
         if (this.profileImage != null) {
-            this.profileImage.delete(); // isDeleted = true
+            this.profileImage.delete(); // File 엔티티의 soft delete 메서드
         }
         this.profileImage = newFile;
     }
 }
+

--- a/backend/src/main/java/com/study/focus/account/dto/GetMyProfileResponse.java
+++ b/backend/src/main/java/com/study/focus/account/dto/GetMyProfileResponse.java
@@ -1,0 +1,21 @@
+package com.study.focus.account.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter @Setter
+@AllArgsConstructor
+public class GetMyProfileResponse {
+    private Long id;
+    private String nickname;
+    private String province;
+    private String district;
+    private String birthDate;
+    private String job;
+    private String preferredCategory;
+    private String profileImageUrl;
+    private Long trustScore;
+}

--- a/backend/src/main/java/com/study/focus/account/dto/GetMyProfileResponse.java
+++ b/backend/src/main/java/com/study/focus/account/dto/GetMyProfileResponse.java
@@ -1,10 +1,10 @@
 package com.study.focus.account.dto;
 
+import com.study.focus.account.domain.Job;
+import com.study.focus.common.domain.Category;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
-
-import java.time.LocalDate;
 
 @Getter @Setter
 @AllArgsConstructor
@@ -14,8 +14,8 @@ public class GetMyProfileResponse {
     private String province;
     private String district;
     private String birthDate;
-    private String job;
-    private String preferredCategory;
+    private Job job;
+    private Category preferredCategory;
     private String profileImageUrl;
     private Long trustScore;
 }

--- a/backend/src/main/java/com/study/focus/account/dto/InitProfileRequest.java
+++ b/backend/src/main/java/com/study/focus/account/dto/InitProfileRequest.java
@@ -1,0 +1,23 @@
+package com.study.focus.account.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter @Setter
+public class InitProfileRequest {
+    @NotBlank
+    private String nickname;
+    @NotBlank
+    private String province;
+    @NotBlank
+    private String district;
+    @NotBlank
+    private String birthDate;
+    @NotBlank
+    private String job;
+    @NotBlank
+    private String preferredCategory;
+}

--- a/backend/src/main/java/com/study/focus/account/dto/InitUserProfileRequest.java
+++ b/backend/src/main/java/com/study/focus/account/dto/InitUserProfileRequest.java
@@ -1,23 +1,31 @@
 package com.study.focus.account.dto;
 
+import com.study.focus.account.domain.Job;
+import com.study.focus.common.domain.Category;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.LocalDate;
-
 @Getter @Setter
-public class InitProfileRequest {
+@AllArgsConstructor
+public class InitUserProfileRequest {
     @NotBlank
     private String nickname;
+
     @NotBlank
     private String province;
+
     @NotBlank
     private String district;
+
     @NotBlank
     private String birthDate;
-    @NotBlank
-    private String job;
-    @NotBlank
-    private String preferredCategory;
+
+    @NotNull
+    private Job job;
+
+    @NotNull
+    private Category preferredCategory;
 }

--- a/backend/src/main/java/com/study/focus/account/dto/UpdateUserProfileRequest.java
+++ b/backend/src/main/java/com/study/focus/account/dto/UpdateUserProfileRequest.java
@@ -1,0 +1,16 @@
+package com.study.focus.account.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter @Setter
+public class UpdateUserProfileRequest {
+    private String nickname;
+    private String province;
+    private String district;
+    private String birthDate;
+    private String job;
+    private String preferredCategory;
+}

--- a/backend/src/main/java/com/study/focus/account/dto/UpdateUserProfileRequest.java
+++ b/backend/src/main/java/com/study/focus/account/dto/UpdateUserProfileRequest.java
@@ -1,16 +1,18 @@
 package com.study.focus.account.dto;
 
+import com.study.focus.account.domain.Job;
+import com.study.focus.common.domain.Category;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.LocalDate;
-
 @Getter @Setter
+@AllArgsConstructor
 public class UpdateUserProfileRequest {
     private String nickname;
     private String province;
     private String district;
     private String birthDate;
-    private String job;
-    private String preferredCategory;
+    private Job job;
+    private Category preferredCategory;
 }

--- a/backend/src/main/java/com/study/focus/account/repository/UserProfileRepository.java
+++ b/backend/src/main/java/com/study/focus/account/repository/UserProfileRepository.java
@@ -3,5 +3,8 @@ package com.study.focus.account.repository;
 import com.study.focus.account.domain.UserProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
+    Optional<UserProfile> findByUserId(Long userId);
 }

--- a/backend/src/main/java/com/study/focus/account/service/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/study/focus/account/service/CustomUserDetailsService.java
@@ -3,39 +3,31 @@ package com.study.focus.account.service;
 import com.study.focus.account.domain.User;
 import com.study.focus.account.dto.CustomUserDetails;
 import com.study.focus.account.repository.UserRepository;
+import com.study.focus.common.exception.BusinessException;
+import com.study.focus.common.exception.UserErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
-    private final UserRepository userRepository; // DB 접근 Repository (가정)
+    private final UserRepository userRepository;
 
-    /**
-     * UserDetailsService 인터페이스의 핵심 메서드입니다.
-     * Spring Security 필터 체인이나, 저희가 만든 TokenAuthenticationFilter에서 호출됩니다.
-     *
-     * @param username 여기서는 JWT의 Subject로 사용한 userId 문자열이 전달됩니다.
-     */
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        // 1. JWT Subject (userId)는 String으로 넘어오므로 Long으로 변환
+    public UserDetails loadUserByUsername(String username) {
         Long userId;
         try {
             userId = Long.valueOf(username);
         } catch (NumberFormatException e) {
-            throw new UsernameNotFoundException("Invalid user ID format: " + username);
+            throw new BusinessException(UserErrorCode.USER_ID_FORMAT_INVALID, e);
         }
 
-        // 2. userId로 DB에서 사용자 정보를 조회
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found with ID: " + userId));
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        // 3. 조회된 Account 객체를 CustomUserDetails로 변환하여 반환
         return new CustomUserDetails(user.getId());
     }
 }

--- a/backend/src/main/java/com/study/focus/account/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/study/focus/account/service/RefreshTokenService.java
@@ -3,6 +3,8 @@ package com.study.focus.account.service;
 import com.study.focus.account.domain.RefreshToken;
 import com.study.focus.account.domain.User;
 import com.study.focus.account.repository.RefreshTokenRepository;
+import com.study.focus.common.exception.BusinessException;
+import com.study.focus.common.exception.UserErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,7 +38,7 @@ public class RefreshTokenService {
 
     public RefreshToken findByRefreshToken(String refreshToken) {
         return refreshTokenRepository.findByToken(refreshToken)
-                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 RefreshToken 입니다."));
+                .orElseThrow(() -> new BusinessException(UserErrorCode.REFRESH_TOKEN_INVALID));
     }
 
     public void deleteByUserId(Long userId) {

--- a/backend/src/main/java/com/study/focus/account/service/UserService.java
+++ b/backend/src/main/java/com/study/focus/account/service/UserService.java
@@ -1,33 +1,122 @@
 package com.study.focus.account.service;
 
+import com.study.focus.account.domain.Job;
 import com.study.focus.account.domain.User;
+import com.study.focus.account.domain.UserProfile;
+import com.study.focus.account.dto.GetMyProfileResponse;
+import com.study.focus.account.dto.InitProfileRequest;
+import com.study.focus.account.dto.UpdateUserProfileRequest;
+import com.study.focus.account.repository.UserProfileRepository;
 import com.study.focus.account.repository.UserRepository;
+import com.study.focus.common.domain.Address;
+import com.study.focus.common.domain.Category;
+import com.study.focus.common.domain.File;
+import com.study.focus.common.dto.FileDetailDto;
+import com.study.focus.common.exception.BusinessException;
+import com.study.focus.common.exception.CommonErrorCode;
+import com.study.focus.common.exception.UserErrorCode;
+import com.study.focus.common.util.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class UserService {
 
     private final UserRepository userRepository;
+    private final S3Uploader s3Uploader;
+    private final UserProfileRepository userProfileRepository;
 
-    // 초기 프로필 설정
-    public void createProfile(Long userId) {
-        // TODO: 프로필 최초 생성
+    /**
+     * 초기 프로필 설정 (이미지 제외)
+     */
+    public void initProfile(Long userId, InitProfileRequest request) {
+        User user = findUser(userId);
+
+        Address address = new Address(request.getProvince(), request.getDistrict());
+        UserProfile profile = UserProfile.create(
+                user,
+                request.getNickname(),
+                address,
+                LocalDate.parse(request.getBirthDate()),
+                Job.valueOf(request.getJob()),            // enum 매핑
+                Category.valueOf(request.getPreferredCategory())
+        );
+
+        userProfileRepository.save(profile);
     }
 
-    // 내 프로필 조회
-    public void getMyProfile(Long userId) {
-        // TODO: 내 프로필 조회
+    /**
+     * 프로필 이미지 등록 / 변경
+     */
+    public String setProfileImage(Long userId, MultipartFile file) {
+        UserProfile profile = findUserProfile(userId);
+
+        // 파일 메타데이터 생성
+        FileDetailDto meta = s3Uploader.makeMetaData(file);
+
+        // 업로드
+        try {
+            s3Uploader.uploadFile(meta.getKey(), file);
+        } catch (Exception e) {
+            throw new BusinessException(UserErrorCode.FILE_UPLOAD_FAIL, e);
+        }
+
+        // File 엔티티 생성 후 교체
+        File newFile = File.ofProfileImage(meta);
+        profile.updateProfileImage(newFile);
+
+        return s3Uploader.getUrlFile(meta.getKey());
     }
 
-    // 내 프로필 수정
-    public void updateMyProfile(Long userId) {
-        // TODO: 내 프로필 수정
+    /**
+     * 프로필 수정 (이미지 제외)
+     */
+    public void updateProfile(Long userId, UpdateUserProfileRequest request) {
+        UserProfile profile = findUserProfile(userId);
+
+        Address newAddress = new Address(request.getProvince(), request.getDistrict());
+        profile.updateProfile(
+                request.getNickname(),
+                newAddress,
+                LocalDate.parse(request.getBirthDate()),
+                Job.valueOf(request.getJob()),
+                Category.valueOf(request.getPreferredCategory())
+        );
     }
 
-    public User findById(Long userId) {
+    /**
+     * 내 프로필 조회
+     */
+    @Transactional(readOnly = true)
+    public GetMyProfileResponse getMyProfile(Long userId) {
+        UserProfile profile = findUserProfile(userId);
+
+        return new GetMyProfileResponse(
+                profile.getUser().getId(),
+                profile.getNickname(),
+                profile.getAddress().getProvince(),
+                profile.getAddress().getDistrict(),
+                profile.getBirthDate().toString(),
+                profile.getJob().name(),
+                profile.getPreferredCategory().name(),
+                profile.getProfileImage() != null ? s3Uploader.getUrlFile(profile.getProfileImage().getFileKey()) : null,
+                profile.getUser().getTrustScore()
+        );
+    }
+
+    private User findUser(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("User not found"));
+                .orElseThrow(() -> new BusinessException(CommonErrorCode.INVALID_REQUEST));
+    }
+
+    private UserProfile findUserProfile(Long userId) {
+        return userProfileRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.FILE_NOT_FOUND));
     }
 }

--- a/backend/src/main/java/com/study/focus/account/service/UserService.java
+++ b/backend/src/main/java/com/study/focus/account/service/UserService.java
@@ -4,7 +4,7 @@ import com.study.focus.account.domain.Job;
 import com.study.focus.account.domain.User;
 import com.study.focus.account.domain.UserProfile;
 import com.study.focus.account.dto.GetMyProfileResponse;
-import com.study.focus.account.dto.InitProfileRequest;
+import com.study.focus.account.dto.InitUserProfileRequest;
 import com.study.focus.account.dto.UpdateUserProfileRequest;
 import com.study.focus.account.repository.UserProfileRepository;
 import com.study.focus.account.repository.UserRepository;
@@ -31,7 +31,7 @@ public class UserService {
     private final S3Uploader s3Uploader;
     private final UserProfileRepository userProfileRepository;
 
-    public void initProfile(Long userId, InitProfileRequest request) {
+    public void initProfile(Long userId, InitUserProfileRequest request) {
         User user = findUser(userId);
 
         Address address = new Address(request.getProvince(), request.getDistrict());
@@ -40,8 +40,8 @@ public class UserService {
                 request.getNickname(),
                 address,
                 LocalDate.parse(request.getBirthDate()),
-                Job.valueOf(request.getJob()),
-                Category.valueOf(request.getPreferredCategory())
+                request.getJob(),
+                request.getPreferredCategory()
         );
 
         userProfileRepository.save(profile);
@@ -72,8 +72,8 @@ public class UserService {
                 request.getNickname(),
                 newAddress,
                 LocalDate.parse(request.getBirthDate()),
-                Job.valueOf(request.getJob()),
-                Category.valueOf(request.getPreferredCategory())
+                request.getJob(),
+                request.getPreferredCategory()
         );
     }
 
@@ -87,8 +87,8 @@ public class UserService {
                 profile.getAddress().getProvince(),
                 profile.getAddress().getDistrict(),
                 profile.getBirthDate().toString(),
-                profile.getJob().name(),
-                profile.getPreferredCategory().name(),
+                profile.getJob(),
+                profile.getPreferredCategory(),
                 profile.getProfileImage() != null ? s3Uploader.getUrlFile(profile.getProfileImage().getFileKey()) : null,
                 profile.getUser().getTrustScore()
         );

--- a/backend/src/main/java/com/study/focus/common/domain/Address.java
+++ b/backend/src/main/java/com/study/focus/common/domain/Address.java
@@ -8,7 +8,7 @@ import lombok.*;
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class Address {
 
     @Column(nullable = false, length = 50)

--- a/backend/src/main/java/com/study/focus/common/domain/File.java
+++ b/backend/src/main/java/com/study/focus/common/domain/File.java
@@ -100,6 +100,13 @@ public class File extends BaseCreatedEntity {
         return f;
     }
 
+    /**
+     * UserProfile 프로필 이미지용 파일 생성
+     */
+    public static File ofProfileImage(FileDetailDto fileDetail) {
+        return base(fileDetail);
+    }
+
     // 공통 생성 로직
     private static File base( FileDetailDto fileDetail) {
         File f = new File();

--- a/backend/src/main/java/com/study/focus/common/exception/UserErrorCode.java
+++ b/backend/src/main/java/com/study/focus/common/exception/UserErrorCode.java
@@ -16,10 +16,20 @@ public enum UserErrorCode implements ErrorCode {
     FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR,"파일 업로드에 실패했습니다"),
     INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST,"잘못된 파일 타입을 요청했습니다."),
     FILE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR,"현재 파일과 관련하여 서버에 문제가 있습니다."),
-    URL_FORBIDDEN(HttpStatus.FORBIDDEN,"사용자는 해당 기능을 사용할 수 없습니다.");
+    URL_FORBIDDEN(HttpStatus.FORBIDDEN,"사용자는 해당 기능을 사용할 수 없습니다."),
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
+    DUPLICATE_LOGIN_ID(HttpStatus.BAD_REQUEST, "이미 존재하는 아이디입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    USER_ID_FORMAT_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 사용자 ID 형식입니다."),
+    REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 RefreshToken 입니다."),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "Refresh Token이 만료되었습니다."),
+    SYSTEM_CREDENTIAL_NOT_FOUND(HttpStatus.NOT_FOUND, "SystemCredential이 존재하지 않습니다."),
+    OAUTH_CREDENTIAL_NOT_FOUND(HttpStatus.NOT_FOUND, "OAuthCredential이 존재하지 않습니다."),
+    PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저의 프로필을 찾을 수 없습니다."),
+    UNSUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 OAuth Provider입니다.");
 
 
-
-    private  final HttpStatus httpStatus;
+    private final HttpStatus httpStatus;
     private final String message;
 }

--- a/backend/src/test/java/com/study/focus/account/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/study/focus/account/controller/UserControllerTest.java
@@ -1,0 +1,192 @@
+package com.study.focus.account.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.study.focus.account.domain.Job;
+import com.study.focus.account.domain.User;
+import com.study.focus.account.domain.UserProfile;
+import com.study.focus.account.dto.CustomUserDetails;
+import com.study.focus.account.dto.InitUserProfileRequest;
+import com.study.focus.account.repository.UserProfileRepository;
+import com.study.focus.account.repository.UserRepository;
+import com.study.focus.common.domain.Address;
+import com.study.focus.common.domain.Category;
+import com.study.focus.common.dto.FileDetailDto;
+import com.study.focus.common.repository.FileRepository;
+import com.study.focus.common.util.S3Uploader;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class UserControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private UserProfileRepository userProfileRepository;
+    @Autowired private FileRepository fileRepository;
+
+    @MockBean  // 실제 구현 대신 Mock 사용
+    private S3Uploader s3Uploader;
+
+    private User user1;
+
+    @BeforeEach
+    void setUp() {
+        user1 = userRepository.save(User.builder()
+                .trustScore(50L)
+                .lastLoginAt(LocalDateTime.now())
+                .build());
+    }
+
+    @AfterEach
+    void tearDown() {
+        fileRepository.deleteAll();
+        userProfileRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("성공: 초기 프로필 설정")
+    void initProfile_success() throws Exception {
+        InitUserProfileRequest request = new InitUserProfileRequest(
+                "홍길동", "서울특별시", "강남구",
+                "2000-01-01", Job.STUDENT, Category.IT
+        );
+
+        mockMvc.perform(post("/api/users/me/profile/basic")
+                        .with(user(new CustomUserDetails(user1.getId())))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(csrf()))
+                .andExpect(status().isCreated());
+
+        assertThat(userProfileRepository.findByUserId(user1.getId())).isPresent();
+    }
+
+    @Test
+    @DisplayName("실패: 초기 프로필 설정 - 잘못된 Job Enum")
+    void initProfile_fail_invalidJob() throws Exception {
+        String payload = """
+            {
+              "nickname": "홍길동",
+              "province": "서울특별시",
+              "district": "강남구",
+              "birthDate": "2000-01-01",
+              "job": "INVALID",
+              "preferredCategory": "IT"
+            }
+            """;
+
+        mockMvc.perform(post("/api/users/me/profile/basic")
+                        .with(user(new CustomUserDetails(user1.getId())))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("성공: 프로필 이미지 업로드")
+    void setProfileImage_success() throws Exception {
+
+        userProfileRepository.save(UserProfile.create(
+                user1,
+                "홍길동",
+                new Address("서울특별시", "강남구"),
+                LocalDate.of(2000, 1, 1),
+                Job.STUDENT,
+                Category.IT
+        ));
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "profile.png",
+                "image/png",
+                "dummy-image".getBytes()
+        );
+
+        // S3Uploader 동작 Mocking
+        FileDetailDto fakeMeta = new FileDetailDto("profile.png", "fake-key", "image/png", 100L);
+        given(s3Uploader.makeMetaData(any(MultipartFile.class))).willReturn(fakeMeta);
+        willDoNothing().given(s3Uploader).uploadFile(eq("fake-key"), any(MultipartFile.class));
+        given(s3Uploader.getUrlFile("fake-key")).willReturn("http://localhost/fake-url");
+
+        mockMvc.perform(multipart("/api/users/me/profile/image")
+                        .file(file)
+                        .with(user(new CustomUserDetails(user1.getId())))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(content().string("http://localhost/fake-url"));
+    }
+
+    @Test
+    @DisplayName("실패: 프로필 이미지 업로드 - 프로필 없음")
+    void setProfileImage_fail_noProfile() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "profile.png", "image/png", "dummy".getBytes()
+        );
+
+        mockMvc.perform(multipart("/api/users/me/profile/image")
+                        .file(file)
+                        .with(user(new CustomUserDetails(999L))) // 존재하지 않는 유저
+                        .with(csrf()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("성공: 내 프로필 조회")
+    void getMyProfile_success() throws Exception {
+        // 프로필 생성
+        InitUserProfileRequest request = new InitUserProfileRequest(
+                "홍길동", "서울특별시", "강남구",
+                "2000-01-01", Job.STUDENT, Category.IT
+        );
+        mockMvc.perform(post("/api/users/me/profile/basic")
+                        .with(user(new CustomUserDetails(user1.getId())))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(csrf()))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/users/me/profile")
+                        .with(user(new CustomUserDetails(user1.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nickname").value("홍길동"))
+                .andExpect(jsonPath("$.job").value("STUDENT"))
+                .andExpect(jsonPath("$.preferredCategory").value("IT"));
+    }
+
+    @Test
+    @DisplayName("실패: 내 프로필 조회 - 프로필 없음")
+    void getMyProfile_fail_notFound() throws Exception {
+        mockMvc.perform(get("/api/users/me/profile")
+                        .with(user(new CustomUserDetails(user1.getId()))))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/backend/src/test/java/com/study/focus/account/service/RefreshTokenServiceTest.java
+++ b/backend/src/test/java/com/study/focus/account/service/RefreshTokenServiceTest.java
@@ -3,6 +3,8 @@ package com.study.focus.account.service;
 import com.study.focus.account.domain.RefreshToken;
 import com.study.focus.account.domain.User;
 import com.study.focus.account.repository.RefreshTokenRepository;
+import com.study.focus.common.exception.BusinessException;
+import com.study.focus.common.exception.UserErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,11 +48,11 @@ class RefreshTokenServiceTest {
     void findByRefreshToken_fail() {
         when(refreshTokenRepository.findByToken("wrong")).thenReturn(Optional.empty());
 
-        IllegalArgumentException ex = assertThrows(
-                IllegalArgumentException.class,
+        BusinessException ex = assertThrows(
+                BusinessException.class,
                 () -> refreshTokenService.findByRefreshToken("wrong")
         );
 
-        assertThat(ex.getMessage()).isEqualTo("유효하지 않은 RefreshToken 입니다.");
+        assertThat(ex.getErrorCode()).isEqualTo(UserErrorCode.REFRESH_TOKEN_INVALID);
     }
 }

--- a/backend/src/test/java/com/study/focus/account/service/TokenServiceTest.java
+++ b/backend/src/test/java/com/study/focus/account/service/TokenServiceTest.java
@@ -4,6 +4,8 @@ import com.study.focus.account.config.jwt.TokenProvider;
 import com.study.focus.account.domain.*;
 import com.study.focus.account.repository.OAuthCredentialRepository;
 import com.study.focus.account.repository.SystemCredentialRepository;
+import com.study.focus.common.exception.BusinessException;
+import com.study.focus.common.exception.UserErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -129,11 +131,12 @@ class TokenServiceTest {
         when(refreshTokenService.findByRefreshToken("expired"))
                 .thenReturn(expired);
 
-        IllegalArgumentException ex = assertThrows(
-                IllegalArgumentException.class,
+        BusinessException ex = assertThrows(
+                BusinessException.class,
                 () -> tokenService.createNewAccessToken("expired")
         );
 
-        assertThat(ex.getMessage()).isEqualTo("Refresh Token이 만료되었습니다.");
+        assertThat(ex.getErrorCode()).isEqualTo(UserErrorCode.REFRESH_TOKEN_EXPIRED);
     }
+
 }

--- a/backend/src/test/java/com/study/focus/account/service/UserServiceTest.java
+++ b/backend/src/test/java/com/study/focus/account/service/UserServiceTest.java
@@ -1,0 +1,183 @@
+package com.study.focus.account.service;
+
+import com.study.focus.account.domain.Job;
+import com.study.focus.account.domain.User;
+import com.study.focus.account.domain.UserProfile;
+import com.study.focus.account.dto.GetMyProfileResponse;
+import com.study.focus.account.dto.InitUserProfileRequest;
+import com.study.focus.account.dto.UpdateUserProfileRequest;
+import com.study.focus.account.repository.UserProfileRepository;
+import com.study.focus.account.repository.UserRepository;
+import com.study.focus.common.domain.Address;
+import com.study.focus.common.domain.Category;
+import com.study.focus.common.domain.File;
+import com.study.focus.common.dto.FileDetailDto;
+import com.study.focus.common.exception.BusinessException;
+import com.study.focus.common.exception.UserErrorCode;
+import com.study.focus.common.util.S3Uploader;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private UserProfileRepository userProfileRepository;
+    @Mock private S3Uploader s3Uploader;
+    @InjectMocks private UserService userService;
+
+    @Test
+    @DisplayName("초기 프로필 설정 성공")
+    void initProfile_success() {
+        // given
+        User user = User.builder().id(1L).build();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        InitUserProfileRequest request = new InitUserProfileRequest(
+                "홍길동", "경상북도", "경산시",
+                "1999-07-15", Job.STUDENT, Category.IT
+        );
+
+        // when
+        userService.initProfile(1L, request);
+
+        // then
+        verify(userProfileRepository).save(any(UserProfile.class));
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 등록 성공")
+    void setProfileImage_success() {
+        // given
+        User user = User.builder().id(1L).build();
+        UserProfile profile = UserProfile.builder().user(user).nickname("홍길동")
+                .address(new Address("경상북도", "경산시"))
+                .birthDate(LocalDate.of(1999, 7, 15))
+                .job(Job.STUDENT).preferredCategory(Category.IT)
+                .build();
+
+        when(userProfileRepository.findByUserId(1L)).thenReturn(Optional.of(profile));
+
+        MultipartFile mockFile = mock(MultipartFile.class);
+        FileDetailDto meta = new FileDetailDto("hong.png", "key-123", "image/png", 123L);
+
+        when(s3Uploader.makeMetaData(mockFile)).thenReturn(meta);
+        doNothing().when(s3Uploader).uploadFile(anyString(), any());
+        when(s3Uploader.getUrlFile("key-123")).thenReturn("https://cdn.example.com/hong.png");
+
+        // when
+        String url = userService.setProfileImage(1L, mockFile);
+
+        // then
+        assertThat(url).isEqualTo("https://cdn.example.com/hong.png");
+        assertThat(profile.getProfileImage()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 업로드 실패 시 예외 발생")
+    void setProfileImage_uploadFail() {
+        // given
+        User user = User.builder().id(1L).build();
+        UserProfile profile = UserProfile.builder().user(user).nickname("홍길동")
+                .address(new Address("경상북도", "경산시"))
+                .birthDate(LocalDate.of(1999, 7, 15))
+                .job(Job.STUDENT).preferredCategory(Category.IT)
+                .build();
+
+        when(userProfileRepository.findByUserId(1L)).thenReturn(Optional.of(profile));
+
+        MultipartFile mockFile = mock(MultipartFile.class);
+        FileDetailDto meta = new FileDetailDto("hong.png", "key-123", "image/png", 123L);
+
+        when(s3Uploader.makeMetaData(mockFile)).thenReturn(meta);
+        doThrow(new RuntimeException("S3 error")).when(s3Uploader).uploadFile(anyString(), any());
+
+        // when & then
+        assertThatThrownBy(() -> userService.setProfileImage(1L, mockFile))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(UserErrorCode.FILE_UPLOAD_FAIL.getMessage());
+    }
+
+    @Test
+    @DisplayName("프로필 수정 성공")
+    void updateProfile_success() {
+        // given
+        User user = User.builder().id(1L).build();
+        UserProfile profile = UserProfile.builder().user(user).nickname("홍길동")
+                .address(new Address("경상북도", "경산시"))
+                .birthDate(LocalDate.of(1999, 7, 15))
+                .job(Job.STUDENT).preferredCategory(Category.IT)
+                .build();
+
+        when(userProfileRepository.findByUserId(1L)).thenReturn(Optional.of(profile));
+
+        UpdateUserProfileRequest request = new UpdateUserProfileRequest(
+                "임꺽정", "서울특별시", "강남구", "2000-01-01", Job.FREELANCER, Category.LANGUAGE
+        );
+
+        // when
+        userService.updateProfile(1L, request);
+
+        // then
+        assertThat(profile.getNickname()).isEqualTo("임꺽정");
+        assertThat(profile.getAddress().getProvince()).isEqualTo("서울특별시");
+    }
+
+    @Test
+    @DisplayName("내 프로필 조회 성공")
+    void getMyProfile_success() {
+        // given
+        User user = User.builder().id(1L).trustScore(80L).build();
+        FileDetailDto meta = FileDetailDto.builder()
+                .originalFileName("hong.png")
+                .key("key-123")
+                .contentType("image/png")
+                .fileSize(100L)
+                .build();
+
+        File file = File.ofProfileImage(meta);
+
+        UserProfile profile = UserProfile.builder().user(user).nickname("홍길동")
+                .address(new Address("경상북도", "경산시"))
+                .birthDate(LocalDate.of(1999, 7, 15))
+                .job(Job.STUDENT).preferredCategory(Category.IT)
+                .profileImage(file)
+                .build();
+
+        when(userProfileRepository.findByUserId(1L)).thenReturn(Optional.of(profile));
+        when(s3Uploader.getUrlFile("key-123")).thenReturn("https://cdn.example.com/hong.png");
+
+        // when
+        GetMyProfileResponse response = userService.getMyProfile(1L);
+
+        // then
+        assertThat(response.getNickname()).isEqualTo("홍길동");
+        assertThat(response.getProfileImageUrl()).isEqualTo("https://cdn.example.com/hong.png");
+        assertThat(response.getTrustScore()).isEqualTo(80L);
+    }
+
+    @Test
+    @DisplayName("내 프로필 조회 실패 - 프로필 없음")
+    void getMyProfile_profileNotFound() {
+        // given
+        when(userProfileRepository.findByUserId(1L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.getMyProfile(1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(UserErrorCode.PROFILE_NOT_FOUND.getMessage());
+    }
+}

--- a/backend/src/test/java/com/study/focus/assignment/AssignmentIntegrationTest.java
+++ b/backend/src/test/java/com/study/focus/assignment/AssignmentIntegrationTest.java
@@ -29,6 +29,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -117,7 +118,7 @@ class AssignmentIntegrationTest {
                         .with(user(new CustomUserDetails(user1.getId())))) // setUp에서 생성된 user를 사용
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(2))
-                .andExpect(jsonPath("$[0].title").value("2"));
+                .andExpect(jsonPath("$[*].title").value(containsInAnyOrder("1", "2")));
     }
 
 


### PR DESCRIPTION
## 개요
- 유저 프로필 기능(`initProfile`, `updateProfile`, `getMyProfile`, `setProfileImage`) 개발
- 공통 예외 처리(`BusinessException` + `CommonErrorCode`, `UserErrorCode`) 적용
- 테스트 코드 전반 보강 (Account, User)

## 주요 변경 사항
- 회원가입 및 OAuth 로그인 후 프로필 설정 플로우 지원
- 프로필 미설정 시 `PROFILE_NOT_FOUND` 예외 반환 → 프론트에서 리다이렉트 처리 가능
- DB 정렬 조건에 의존한 불안정한 테스트 케이스 수정
- 통합/단위 테스트 보강을 통해 주요 시나리오 검증 완료

## 기타
- 세부 변경 내역은 커밋 로그 참고