### PR TITLE
feat(Get)AnnouncementDeatil: 공지 사항 세부 데이터 가져오기 구현 및 테스트 코드 작성

### DIFF
--- a/backend/src/main/java/com/study/focus/account/domain/UserProfile.java
+++ b/backend/src/main/java/com/study/focus/account/domain/UserProfile.java
@@ -20,7 +20,7 @@ public class UserProfile extends BaseUpdatedEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User user;
 
@@ -41,7 +41,7 @@ public class UserProfile extends BaseUpdatedEntity {
     @Column(nullable = false)
     private Category preferredCategory;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "profile_image_id")
     private File profileImage;
 

--- a/backend/src/main/java/com/study/focus/account/service/UserService.java
+++ b/backend/src/main/java/com/study/focus/account/service/UserService.java
@@ -14,6 +14,7 @@ import com.study.focus.common.domain.File;
 import com.study.focus.common.dto.FileDetailDto;
 import com.study.focus.common.exception.BusinessException;
 import com.study.focus.common.exception.UserErrorCode;
+import com.study.focus.common.repository.FileRepository;
 import com.study.focus.common.util.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,6 +31,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final S3Uploader s3Uploader;
     private final UserProfileRepository userProfileRepository;
+    private final FileRepository fileRepository;
 
     public void initProfile(Long userId, InitUserProfileRequest request) {
         User user = findUser(userId);
@@ -59,7 +61,9 @@ public class UserService {
         }
 
         File newFile = File.ofProfileImage(meta);
+        fileRepository.save(newFile);
         profile.updateProfileImage(newFile);
+
 
         return s3Uploader.getUrlFile(meta.getKey());
     }

--- a/backend/src/main/java/com/study/focus/announcement/controller/AnnouncementController.java
+++ b/backend/src/main/java/com/study/focus/announcement/controller/AnnouncementController.java
@@ -2,6 +2,7 @@ package com.study.focus.announcement.controller;
 
 
 import com.study.focus.account.dto.CustomUserDetails;
+import com.study.focus.announcement.dto.GetAnnouncementDetailResponse;
 import com.study.focus.announcement.dto.GetAnnouncementsResponse;
 import com.study.focus.announcement.service.AnnouncementService;
 import lombok.RequiredArgsConstructor;
@@ -68,7 +69,13 @@ public class AnnouncementController {
 
     // 공지 상세 데이터 가져오기
     @GetMapping("/{announcementId}")
-    public void getAnnouncementDetail(@PathVariable Long studyId, @PathVariable Long announcementId) {}
+    public ResponseEntity<GetAnnouncementDetailResponse> getAnnouncementDetail(@PathVariable Long studyId, @PathVariable Long announcementId,
+                                      @AuthenticationPrincipal CustomUserDetails user) {
+        log.info("Get announcement Detail Data for studyId: {} , for announcementId: {}", studyId,announcementId);
+        Long userId = user.getUserId();
+        GetAnnouncementDetailResponse detailResponse = announcementService.getAnnouncementDetail(studyId, announcementId, userId);
+        return ResponseEntity.ok(detailResponse);
+    }
 
 
 

--- a/backend/src/main/java/com/study/focus/announcement/dto/AnnouncementComments.java
+++ b/backend/src/main/java/com/study/focus/announcement/dto/AnnouncementComments.java
@@ -1,0 +1,20 @@
+package com.study.focus.announcement.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Setter
+@Builder
+@Getter
+public class AnnouncementComments {
+
+    private Long commentId;
+    private String userName;
+    private String userProfileImageUrl;
+    private String content;
+    private LocalDateTime createdAt;
+
+}

--- a/backend/src/main/java/com/study/focus/announcement/dto/AnnouncementFiles.java
+++ b/backend/src/main/java/com/study/focus/announcement/dto/AnnouncementFiles.java
@@ -1,0 +1,18 @@
+package com.study.focus.announcement.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Builder
+@Getter
+@AllArgsConstructor
+public class AnnouncementFiles {
+
+    private  Long fileId;
+    private String fileName;
+    private String fileUrl;
+
+}

--- a/backend/src/main/java/com/study/focus/announcement/dto/GetAnnouncementDetailResponse.java
+++ b/backend/src/main/java/com/study/focus/announcement/dto/GetAnnouncementDetailResponse.java
@@ -1,0 +1,24 @@
+package com.study.focus.announcement.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+@Setter
+@Getter
+public class GetAnnouncementDetailResponse {
+    Long announcementId;
+    Long studyId;
+    String title;
+    String content;
+    LocalDateTime updatedAt;
+    String userName;
+    String userProfileImageUrl;
+    List<AnnouncementFiles> files;
+    List<AnnouncementComments> comments;
+
+}

--- a/backend/src/main/java/com/study/focus/announcement/repository/AnnouncementRepository.java
+++ b/backend/src/main/java/com/study/focus/announcement/repository/AnnouncementRepository.java
@@ -11,4 +11,6 @@ import java.util.Optional;
 public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
     List<Announcement> findAllByStudyId(Long study_id);
     Optional<Announcement> findByIdAndStudy_IdAndAuthor_Id(Long id, Long study_id, Long author_id);
+
+    Optional<Announcement> findByIdAndStudyId(Long announcementId, Long studyId);
 }

--- a/backend/src/test/java/com/study/focus/account/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/study/focus/account/controller/UserControllerTest.java
@@ -14,6 +14,7 @@ import com.study.focus.common.dto.FileDetailDto;
 import com.study.focus.common.repository.FileRepository;
 import com.study.focus.common.util.S3Uploader;
 import org.junit.jupiter.api.*;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -51,7 +52,7 @@ class UserControllerTest {
     @Autowired private UserProfileRepository userProfileRepository;
     @Autowired private FileRepository fileRepository;
 
-    @MockBean  // 실제 구현 대신 Mock 사용
+    @MockBean// 실제 구현 대신 Mock 사용
     private S3Uploader s3Uploader;
 
     private User user1;
@@ -66,8 +67,8 @@ class UserControllerTest {
 
     @AfterEach
     void tearDown() {
-        fileRepository.deleteAll();
         userProfileRepository.deleteAll();
+        fileRepository.deleteAll();
         userRepository.deleteAll();
     }
 

--- a/backend/src/test/java/com/study/focus/account/service/UserServiceTest.java
+++ b/backend/src/test/java/com/study/focus/account/service/UserServiceTest.java
@@ -14,6 +14,7 @@ import com.study.focus.common.domain.File;
 import com.study.focus.common.dto.FileDetailDto;
 import com.study.focus.common.exception.BusinessException;
 import com.study.focus.common.exception.UserErrorCode;
+import com.study.focus.common.repository.FileRepository;
 import com.study.focus.common.util.S3Uploader;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,7 @@ class UserServiceTest {
     @Mock private UserRepository userRepository;
     @Mock private UserProfileRepository userProfileRepository;
     @Mock private S3Uploader s3Uploader;
+    @Mock private FileRepository fileRepository;
     @InjectMocks private UserService userService;
 
     @Test
@@ -77,6 +79,8 @@ class UserServiceTest {
         when(s3Uploader.makeMetaData(mockFile)).thenReturn(meta);
         doNothing().when(s3Uploader).uploadFile(anyString(), any());
         when(s3Uploader.getUrlFile("key-123")).thenReturn("https://cdn.example.com/hong.png");
+        when(fileRepository.save(any(File.class)))
+                .thenReturn(File.ofProfileImage(meta));
 
         // when
         String url = userService.setProfileImage(1L, mockFile);

--- a/backend/src/test/java/com/study/focus/announcement/AnnouncementUnitTest.java
+++ b/backend/src/test/java/com/study/focus/announcement/AnnouncementUnitTest.java
@@ -1,12 +1,17 @@
 package com.study.focus.announcement;
 
+import com.study.focus.account.domain.Job;
 import com.study.focus.account.domain.User;
+import com.study.focus.account.dto.GetMyProfileResponse;
+import com.study.focus.account.service.UserService;
 import com.study.focus.announcement.domain.Announcement;
 import com.study.focus.announcement.domain.Comment;
+import com.study.focus.announcement.dto.GetAnnouncementDetailResponse;
 import com.study.focus.announcement.dto.GetAnnouncementsResponse;
 import com.study.focus.announcement.repository.AnnouncementRepository;
 import com.study.focus.announcement.repository.CommentRepository;
 import com.study.focus.announcement.service.AnnouncementService;
+import com.study.focus.common.domain.Category;
 import com.study.focus.common.domain.File;
 import com.study.focus.common.dto.FileDetailDto;
 import com.study.focus.common.exception.BusinessException;
@@ -63,11 +68,15 @@ class AnnouncementUnitTest {
     private S3Uploader s3uploader;
 
 
+    @Mock
+    private UserService userService;
+
+
 
 
     User testUser = User.builder().trustScore(30L).lastLoginAt(LocalDateTime.now()).build();
     Study testStudy = Study.builder().maxMemberCount(30).build();
-    StudyMember teststudyMember = StudyMember.builder().user(testUser).study(testStudy).build();
+    StudyMember teststudyMember = StudyMember.builder().user(testUser).study(testStudy).role(StudyRole.LEADER).build();
 
 
     @Test
@@ -328,8 +337,92 @@ class AnnouncementUnitTest {
                 .isInstanceOf(BusinessException.class);
         then(commentRepository).should(never()).deleteAll(anyList());
         then(announcementRepo).should(never()).delete(any());
-
     }
 
+    @Test
+    @DisplayName("공지 상세 데이터 가져오기 성공 - 댓글/파일 포함")
+    void getAnnouncementDetail_success() {
+        // given
+        Long studyId = 1L;
+        Long userId = 1L;
+        Long announcementId = 10L;
+
+        StudyMember member = StudyMember.builder().id(userId).user(testUser).study(testStudy).role(StudyRole.MEMBER).build();
+        Announcement announcement = Announcement.builder().id(announcementId).study(testStudy).
+                author(member).
+                title("공지 제목").
+                description("공지 내용").build();
+        Comment comment = Comment.builder().id(100L).commenter(member).content("댓글 내용").
+                announcement(announcement).build();
+
+        File file = File.ofAnnouncement(announcement,
+                new FileDetailDto("test.jpg", "testKey", "image/jpg", 10L));
+        ReflectionTestUtils.setField(file, "id", 200L);
+
+        GetMyProfileResponse mockProfile = new GetMyProfileResponse(1L,
+                "testName","testProvince","testDistrict","testBirth",
+                Job.JOB_SEEKER, Category.ACADEMICS,"tesUrl",30L);
+
+        // mocking
+        given(studyMemberRepository.findByStudyIdAndUserId(studyId, userId))
+                .willReturn(Optional.of(member));
+        given(announcementRepo.findByIdAndStudyId(announcementId, studyId))
+                .willReturn(Optional.of(announcement));
+        given(userService.getMyProfile(any()))
+                .willReturn(mockProfile);
+        given(commentRepository.findAllByAnnouncement_Id(announcementId))
+                .willReturn(List.of(comment));
+        given(fileRepository.findAllByAnnouncement_Id(announcementId))
+                .willReturn(List.of(file));
+        given(s3uploader.getUrlFile(file.getFileKey()))
+                .willReturn("https://s3/testKey");
+
+        // when
+       GetAnnouncementDetailResponse result =
+               announcementService.getAnnouncementDetail(studyId, announcementId, userId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getAnnouncementId()).isEqualTo(announcementId);
+        assertThat(result.getTitle()).isEqualTo("공지 제목");
+        assertThat(result.getContent()).isEqualTo("공지 내용");
+        assertThat(result.getUserName()).isEqualTo("testName");
+        assertThat(result.getUserProfileImageUrl()).isEqualTo("tesUrl");
+        assertThat(result.getComments()).hasSize(1);
+        assertThat(result.getFiles()).hasSize(1);
+        then(userService).should(atLeastOnce()).getMyProfile(any());
+        then(s3uploader).should(times(1)).getUrlFile(file.getFileKey());
+    }
+
+
+    @Test
+    @DisplayName("공지 상세 데이터 가져오기 실패 - 스터디 멤버 아닌 경우")
+    void getAnnouncementDetail_fail_NotStudyMember() {
+        Long studyId = 1L;
+        Long userId = 1L;
+        Long announcementId = 10L;
+
+        given(studyMemberRepository.findByStudyIdAndUserId(studyId, userId))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> announcementService.getAnnouncementDetail(studyId, announcementId, userId))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("공지 상세 데이터 가져오기 실패 - 공지가 존재하지 않음")
+    void getAnnouncementDetail_fail_AnnouncementNotFound() {
+        Long studyId = 1L;
+        Long userId = 1L;
+        Long announcementId = 10L;
+
+        given(studyMemberRepository.findByStudyIdAndUserId(studyId, userId))
+                .willReturn(Optional.of(teststudyMember));
+        given(announcementRepo.findByIdAndStudyId(announcementId, studyId))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> announcementService.getAnnouncementDetail(studyId, announcementId, userId))
+                .isInstanceOf(BusinessException.class);
+    }
 
 }


### PR DESCRIPTION
- 공지사항 세부 데이터 가져오기에 대한 기능 구현 및 통합, 단위 테스트 코드 작성 
- 유저 프로필 도메인에서 profileImage과 user에 대한 cascade 종속성 옵션 삭제 
-  위에  profileImage에 대한 종속성 제거로 인해 Userserivce 코드에  setProfileImage 함수에서  프로필 이미지를 추가하기 전 해당 파일을 DB에 저장하는 로직을 추가하였습니다. 
- 위 서비스 코드 변경으로 인해  UserServiceTest에서 Mock 객체인 FileRepository fileRepository를 추가하고  프로필 이미지 등록 성공 테스트를 일부 수정하였습니다.
- profileImage의 Cascade 종속성 제거로 인해  UserControllerTest의 AfterEach 함수에서 유저 프로필이 파일의 외래키를 가지고 있어 유저 프로필 삭제를 먼저하고, 파일을 삭제하도록 순서를 변경했습니다.