### PR TITLE
메인화면 데이터 조회 기능 구현 및 Cascade 제거에 따른 테스트 수정

### DIFF
--- a/backend/src/main/java/com/study/focus/account/domain/UserProfile.java
+++ b/backend/src/main/java/com/study/focus/account/domain/UserProfile.java
@@ -20,7 +20,7 @@ public class UserProfile extends BaseUpdatedEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User user;
 
@@ -41,7 +41,7 @@ public class UserProfile extends BaseUpdatedEntity {
     @Column(nullable = false)
     private Category preferredCategory;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "profile_image_id")
     private File profileImage;
 

--- a/backend/src/main/java/com/study/focus/account/service/UserService.java
+++ b/backend/src/main/java/com/study/focus/account/service/UserService.java
@@ -14,6 +14,7 @@ import com.study.focus.common.domain.File;
 import com.study.focus.common.dto.FileDetailDto;
 import com.study.focus.common.exception.BusinessException;
 import com.study.focus.common.exception.UserErrorCode;
+import com.study.focus.common.repository.FileRepository;
 import com.study.focus.common.util.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,6 +31,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final S3Uploader s3Uploader;
     private final UserProfileRepository userProfileRepository;
+    private final FileRepository fileRepository;
 
     public void initProfile(Long userId, InitUserProfileRequest request) {
         User user = findUser(userId);
@@ -58,7 +60,7 @@ public class UserService {
             throw new BusinessException(UserErrorCode.FILE_UPLOAD_FAIL, e);
         }
 
-        File newFile = File.ofProfileImage(meta);
+        File newFile = fileRepository.save(File.ofProfileImage(meta));
         profile.updateProfileImage(newFile);
 
         return s3Uploader.getUrlFile(meta.getKey());

--- a/backend/src/main/java/com/study/focus/common/dto/StudyDto.java
+++ b/backend/src/main/java/com/study/focus/common/dto/StudyDto.java
@@ -1,0 +1,37 @@
+package com.study.focus.common.dto;
+
+import com.study.focus.study.domain.StudyProfile;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StudyDto {
+    private Long id;
+    private String title;
+    private int maxMemberCount;
+    private int memberCount;
+    private long bookmarkCount;
+    private String bio;
+    private String category;
+    private long trustScore;
+    private boolean bookmarked;
+
+    public static StudyDto of(StudyProfile profile,
+                              int memberCount,
+                              long bookmarkCount,
+                              long trustScore,
+                              boolean bookmarked) {
+        return new StudyDto(
+                profile.getStudy().getId(),
+                profile.getTitle(),
+                profile.getStudy().getMaxMemberCount(),
+                memberCount,
+                bookmarkCount,
+                profile.getBio(),
+                profile.getCategory().name(),
+                trustScore,
+                bookmarked
+        );
+    }
+}

--- a/backend/src/main/java/com/study/focus/home/controller/HomeController.java
+++ b/backend/src/main/java/com/study/focus/home/controller/HomeController.java
@@ -1,12 +1,26 @@
 package com.study.focus.home.controller;
 
+import com.study.focus.account.dto.CustomUserDetails;
+import com.study.focus.home.dto.HomeResponse;
+import com.study.focus.home.service.HomeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/home")
+@RequiredArgsConstructor
 public class HomeController {
 
-    // 메인화면 데이터 가져오기
+    private final HomeService homeService;
+
+    /**
+     * 메인화면 데이터 가져오기
+     */
     @GetMapping
-    public void getHomeData() {}
+    public ResponseEntity<HomeResponse> getHomeData(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
+        return ResponseEntity.ok(homeService.getHomeData(userId));
+    }
 }

--- a/backend/src/main/java/com/study/focus/home/dto/HomeResponse.java
+++ b/backend/src/main/java/com/study/focus/home/dto/HomeResponse.java
@@ -1,0 +1,32 @@
+package com.study.focus.home.dto;
+
+import com.study.focus.account.domain.UserProfile;
+import com.study.focus.common.dto.StudyDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class HomeResponse {
+
+    private UserDto user;
+    private List<StudyDto> topStudies;
+
+    @Getter
+    @AllArgsConstructor
+    public static class UserDto {
+        private String nickname;
+        private String profileImageUrl;
+        private String province;
+        private String district;
+
+        public UserDto(UserProfile profile, String profileImageUrl) {
+            this.nickname = profile.getNickname();
+            this.profileImageUrl = profileImageUrl;
+            this.province = profile.getAddress() != null ? profile.getAddress().getProvince() : null;
+            this.district = profile.getAddress() != null ? profile.getAddress().getDistrict() : null;
+        }
+    }
+}

--- a/backend/src/main/java/com/study/focus/home/service/HomeService.java
+++ b/backend/src/main/java/com/study/focus/home/service/HomeService.java
@@ -1,12 +1,67 @@
 package com.study.focus.home.service;
 
+import com.study.focus.account.domain.UserProfile;
+import com.study.focus.account.repository.UserProfileRepository;
+import com.study.focus.common.dto.StudyDto;
+import com.study.focus.common.exception.BusinessException;
+import com.study.focus.common.exception.UserErrorCode;
+import com.study.focus.common.util.S3Uploader;
+import com.study.focus.home.dto.HomeResponse;
+import com.study.focus.study.domain.StudyMemberStatus;
+import com.study.focus.study.domain.StudyProfile;
+import com.study.focus.study.repository.BookmarkRepository;
+import com.study.focus.study.repository.StudyMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class HomeService {
 
-    // 메인화면 데이터 가져오기
-    public void getHomeData(Long userId) {
-        // TODO: 로그인한 유저 기준으로 메인화면 데이터 조합
+    private final UserProfileRepository userProfileRepository;
+    private final StudyMemberRepository studyMemberRepository;
+    private final BookmarkRepository bookmarkRepository;
+    private final S3Uploader s3Uploader;
+
+    @Transactional(readOnly = true)
+    public HomeResponse getHomeData(Long userId) {
+        // 1. 유저 프로필 조회
+        UserProfile profile = userProfileRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.PROFILE_NOT_FOUND));
+
+        String profileImageUrl = profile.getProfileImage() != null
+                ? s3Uploader.getUrlFile(profile.getProfileImage().getFileKey())
+                : null;
+
+        // 2. 상위 스터디 조회 (방장 trustScore 내림차순 10개)
+        List<StudyProfile> topProfiles =
+                studyMemberRepository.findTop10StudyProfiles(PageRequest.of(0, 10));
+
+        // 3. 유저가 찜한 스터디 ID 목록 조회
+        Set<Long> bookmarkedStudyIds = bookmarkRepository.findAllByUserId(userId).stream()
+                .map(b -> b.getStudy().getId())
+                .collect(Collectors.toSet());
+
+        // 4. DTO 변환
+        List<StudyDto> studyDtos = topProfiles.stream()
+                .map(sp -> {
+                    Long studyId = sp.getStudy().getId();
+
+                    int memberCount = (int) studyMemberRepository.countByStudyIdAndStatus(studyId, StudyMemberStatus.JOINED);
+                    long bookmarkCount = bookmarkRepository.countByStudyId(studyId);
+                    long trustScore = studyMemberRepository.findLeaderTrustScoreByStudyId(studyId).orElse(0L);
+                    boolean bookmarked = bookmarkedStudyIds.contains(studyId);
+
+                    return StudyDto.of(sp, memberCount, bookmarkCount, trustScore, bookmarked);
+                })
+                .toList();
+
+        return new HomeResponse(new HomeResponse.UserDto(profile, profileImageUrl), studyDtos);
     }
 }

--- a/backend/src/main/java/com/study/focus/study/domain/StudyMember.java
+++ b/backend/src/main/java/com/study/focus/study/domain/StudyMember.java
@@ -34,7 +34,7 @@ public class StudyMember extends BaseCreatedEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private StudyRole role = MEMBER;
+    private StudyRole role;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/backend/src/main/java/com/study/focus/study/domain/StudyProfile.java
+++ b/backend/src/main/java/com/study/focus/study/domain/StudyProfile.java
@@ -17,7 +17,7 @@ public class StudyProfile extends BaseUpdatedEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "study_id", nullable = false, unique = true)
     private Study study;
 
@@ -36,8 +36,4 @@ public class StudyProfile extends BaseUpdatedEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Category category;
-
-    @Column(nullable = false, length = 512)
-    @Builder.Default
-    private String profileImageUrl = "https://example.com/default_profile.png";
 }

--- a/backend/src/main/java/com/study/focus/study/repository/BookmarkRepository.java
+++ b/backend/src/main/java/com/study/focus/study/repository/BookmarkRepository.java
@@ -5,8 +5,13 @@ import com.study.focus.study.domain.Bookmark;
 import com.study.focus.study.domain.Study;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     Optional<Bookmark> findByUserAndStudy(User user, Study study);
+
+    List<Bookmark> findAllByUserId(Long userId);
+
+    long countByStudyId(Long studyId);
 }

--- a/backend/src/main/java/com/study/focus/study/repository/StudyMemberRepository.java
+++ b/backend/src/main/java/com/study/focus/study/repository/StudyMemberRepository.java
@@ -1,12 +1,12 @@
 package com.study.focus.study.repository;
 
-import com.study.focus.study.domain.Study;
-import com.study.focus.study.domain.StudyMember;
-import com.study.focus.study.domain.StudyMemberStatus;
-import com.study.focus.study.domain.StudyRole;
+import com.study.focus.study.domain.*;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -18,4 +18,29 @@ public interface StudyMemberRepository extends JpaRepository<StudyMember,Long> {
    long countByStudyIdAndStatus(Long studyId, StudyMemberStatus status);
 
    boolean existsByStudyIdAndUserIdAndStatus(Long studyId, Long userId, StudyMemberStatus status);
+
+    /**
+     * 방장의 trustScore 기준 내림차순 상위 10개 스터디 프로필 조회
+     */
+    @Query("""
+        SELECT sp
+        FROM StudyMember sm
+        JOIN sm.user u
+        JOIN Study s ON sm.study = s
+        JOIN StudyProfile sp ON sp.study = s
+        WHERE sm.role = com.study.focus.study.domain.StudyRole.LEADER
+          AND sm.status = com.study.focus.study.domain.StudyMemberStatus.JOINED
+        ORDER BY u.trustScore DESC
+        """)
+    List<StudyProfile> findTop10StudyProfiles(Pageable pageable);
+
+    @Query("""
+        SELECT u.trustScore
+        FROM StudyMember sm
+        JOIN sm.user u
+        WHERE sm.study.id = :studyId
+          AND sm.role = com.study.focus.study.domain.StudyRole.LEADER
+          AND sm.status = com.study.focus.study.domain.StudyMemberStatus.JOINED
+        """)
+    Optional<Long> findLeaderTrustScoreByStudyId(Long studyId);
 }

--- a/backend/src/test/java/com/study/focus/account/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/study/focus/account/controller/UserControllerTest.java
@@ -10,6 +10,7 @@ import com.study.focus.account.repository.UserProfileRepository;
 import com.study.focus.account.repository.UserRepository;
 import com.study.focus.common.domain.Address;
 import com.study.focus.common.domain.Category;
+import com.study.focus.common.domain.File;
 import com.study.focus.common.dto.FileDetailDto;
 import com.study.focus.common.repository.FileRepository;
 import com.study.focus.common.util.S3Uploader;
@@ -66,8 +67,8 @@ class UserControllerTest {
 
     @AfterEach
     void tearDown() {
-        fileRepository.deleteAll();
         userProfileRepository.deleteAll();
+        fileRepository.deleteAll();
         userRepository.deleteAll();
     }
 
@@ -133,6 +134,7 @@ class UserControllerTest {
 
         // S3Uploader 동작 Mocking
         FileDetailDto fakeMeta = new FileDetailDto("profile.png", "fake-key", "image/png", 100L);
+
         given(s3Uploader.makeMetaData(any(MultipartFile.class))).willReturn(fakeMeta);
         willDoNothing().given(s3Uploader).uploadFile(eq("fake-key"), any(MultipartFile.class));
         given(s3Uploader.getUrlFile("fake-key")).willReturn("http://localhost/fake-url");

--- a/backend/src/test/java/com/study/focus/account/service/UserServiceTest.java
+++ b/backend/src/test/java/com/study/focus/account/service/UserServiceTest.java
@@ -14,6 +14,7 @@ import com.study.focus.common.domain.File;
 import com.study.focus.common.dto.FileDetailDto;
 import com.study.focus.common.exception.BusinessException;
 import com.study.focus.common.exception.UserErrorCode;
+import com.study.focus.common.repository.FileRepository;
 import com.study.focus.common.util.S3Uploader;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,7 @@ class UserServiceTest {
     @Mock private UserRepository userRepository;
     @Mock private UserProfileRepository userProfileRepository;
     @Mock private S3Uploader s3Uploader;
+    @Mock private FileRepository fileRepository;
     @InjectMocks private UserService userService;
 
     @Test
@@ -73,6 +75,9 @@ class UserServiceTest {
 
         MultipartFile mockFile = mock(MultipartFile.class);
         FileDetailDto meta = new FileDetailDto("hong.png", "key-123", "image/png", 123L);
+
+        File savedFile = File.ofProfileImage(meta);
+        when(fileRepository.save(any(File.class))).thenReturn(savedFile);
 
         when(s3Uploader.makeMetaData(mockFile)).thenReturn(meta);
         doNothing().when(s3Uploader).uploadFile(anyString(), any());

--- a/backend/src/test/java/com/study/focus/home/HomeControllerTest.java
+++ b/backend/src/test/java/com/study/focus/home/HomeControllerTest.java
@@ -1,0 +1,234 @@
+package com.study.focus.home;
+
+import com.study.focus.account.domain.Job;
+import com.study.focus.account.domain.User;
+import com.study.focus.account.domain.UserProfile;
+import com.study.focus.account.dto.CustomUserDetails;
+import com.study.focus.account.repository.UserProfileRepository;
+import com.study.focus.account.repository.UserRepository;
+import com.study.focus.common.domain.Address;
+import com.study.focus.common.domain.Category;
+import com.study.focus.common.domain.File;
+import com.study.focus.common.dto.FileDetailDto;
+import com.study.focus.common.repository.FileRepository;
+import com.study.focus.common.util.S3Uploader;
+import com.study.focus.study.domain.*;
+import com.study.focus.study.repository.BookmarkRepository;
+import com.study.focus.study.repository.StudyMemberRepository;
+import com.study.focus.study.repository.StudyProfileRepository;
+import com.study.focus.study.repository.StudyRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.stream.IntStream;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class HomeControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private UserProfileRepository userProfileRepository;
+    @Autowired private StudyRepository studyRepository;
+    @Autowired private StudyProfileRepository studyProfileRepository;
+    @Autowired private StudyMemberRepository studyMemberRepository;
+    @Autowired private BookmarkRepository bookmarkRepository;
+    @Autowired private FileRepository fileRepository;
+
+    @MockBean
+    private S3Uploader s3Uploader;
+
+    private User user;
+    private UserProfile profile;
+    private Study study;
+    private StudyProfile studyProfile;
+
+    @BeforeEach
+    void setUp() {
+        // 유저 저장
+        user = userRepository.save(User.builder()
+                .trustScore(80L)
+                .lastLoginAt(LocalDateTime.now())
+                .build());
+
+        // 더미 파일 생성
+        File file = fileRepository.save(
+                File.ofProfileImage(new FileDetailDto(
+                        "profile.png",
+                        "test-key",
+                        "image/png",
+                        123L
+                ))
+        );
+
+        // 유저 프로필 저장 (이미지 포함)
+        profile = userProfileRepository.save(UserProfile.builder()
+                .user(user)
+                .nickname("홍길동")
+                .address(new Address("경상북도", "경산시"))
+                .birthDate(LocalDate.of(2000, 1, 1))
+                .job(Job.STUDENT)
+                .preferredCategory(Category.IT)
+                .profileImage(file)
+                .build());
+
+        // 스터디 저장
+        study = studyRepository.save(Study.builder()
+                .maxMemberCount(5)
+                .build());
+
+        // 스터디 프로필 저장 (주소 포함)
+        studyProfile = studyProfileRepository.save(StudyProfile.builder()
+                .study(study)
+                .title("백엔드 스터디")
+                .bio("백엔드 개발자를 위한 스터디")
+                .category(Category.IT)
+                .address(new Address("경상북도", "경산시"))
+                .build());
+
+        // 스터디 멤버 (리더) 등록
+        studyMemberRepository.save(StudyMember.builder()
+                .study(study)
+                .user(user)
+                .role(StudyRole.LEADER)
+                .status(StudyMemberStatus.JOINED)
+                .build());
+
+        // 북마크 등록
+        bookmarkRepository.save(Bookmark.builder()
+                .study(study)
+                .user(user)
+                .build());
+
+        // S3Uploader Mock - 항상 동일한 URL 리턴
+        when(s3Uploader.getUrlFile(anyString()))
+                .thenReturn("https://test-bucket.s3.ap-northeast-2.amazonaws.com/profile.png");
+    }
+
+    @AfterEach
+    void tearDown() {
+        bookmarkRepository.deleteAll();
+        studyMemberRepository.deleteAll();
+        studyProfileRepository.deleteAll();
+        studyRepository.deleteAll();
+        userProfileRepository.deleteAll();
+        userRepository.deleteAll();
+        fileRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("성공: 홈 데이터 조회 API")
+    void getHomeData_success() throws Exception {
+        mockMvc.perform(get("/api/home")
+                        .with(user(new CustomUserDetails(user.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.user.nickname").value("홍길동"))
+                .andExpect(jsonPath("$.user.profileImageUrl")
+                        .value("https://test-bucket.s3.ap-northeast-2.amazonaws.com/profile.png"))
+                .andExpect(jsonPath("$.topStudies[0].title").value("백엔드 스터디"))
+                .andExpect(jsonPath("$.topStudies[0].trustScore").value(80))
+                .andExpect(jsonPath("$.topStudies[0].bookmarked").value(true));
+    }
+
+    @Test
+    @DisplayName("실패: 프로필 없음 → 404 반환")
+    void getHomeData_fail_profileNotFound() throws Exception {
+        userProfileRepository.delete(profile);
+
+        mockMvc.perform(get("/api/home")
+                        .with(user(new CustomUserDetails(user.getId()))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.detail").value("해당 유저의 프로필을 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("성공: 프로필 이미지 없는 경우 → profileImageUrl 없음")
+    void getHomeData_success_profileImageNull() throws Exception {
+        profile = userProfileRepository.save(
+                UserProfile.builder()
+                        .id(profile.getId())
+                        .user(user)
+                        .nickname(profile.getNickname())
+                        .address(profile.getAddress())
+                        .birthDate(profile.getBirthDate())
+                        .job(profile.getJob())
+                        .preferredCategory(profile.getPreferredCategory())
+                        .profileImage(null)
+                        .build()
+        );
+
+        mockMvc.perform(get("/api/home")
+                        .with(user(new CustomUserDetails(user.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.user.profileImageUrl").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("성공: 스터디 없는 경우 → topStudies = []")
+    void getHomeData_success_noStudies() throws Exception {
+        bookmarkRepository.deleteAll();
+        studyMemberRepository.deleteAll();
+        studyProfileRepository.deleteAll();
+        studyRepository.deleteAll();
+
+        mockMvc.perform(get("/api/home")
+                        .with(user(new CustomUserDetails(user.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.topStudies").isEmpty());
+    }
+
+    @Test
+    @DisplayName("성공: 스터디 10개 초과 → 상위 10개만 반환")
+    void getHomeData_success_top10Only() throws Exception {
+        IntStream.range(0, 15).forEach(i -> {
+            User leader = userRepository.save(User.builder().trustScore(100L - i).build());
+            Study newStudy = studyRepository.save(Study.builder().maxMemberCount(5).build());
+            studyProfileRepository.save(StudyProfile.builder()
+                    .study(newStudy)
+                    .title("스터디" + i)
+                    .bio("테스트 스터디")
+                    .category(Category.IT)
+                    .address(new Address("서울특별시", "강남구"))
+                    .build());
+            studyMemberRepository.save(StudyMember.builder()
+                    .study(newStudy)
+                    .user(leader)
+                    .role(StudyRole.LEADER)
+                    .status(StudyMemberStatus.JOINED)
+                    .build());
+        });
+
+        mockMvc.perform(get("/api/home")
+                        .with(user(new CustomUserDetails(user.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.topStudies.length()").value(10));
+    }
+
+    @Test
+    @DisplayName("성공: 북마크 없는 경우 → bookmarked=false")
+    void getHomeData_success_notBookmarked() throws Exception {
+        bookmarkRepository.deleteAll();
+
+        mockMvc.perform(get("/api/home")
+                        .with(user(new CustomUserDetails(user.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.topStudies[0].bookmarked").value(false));
+    }
+}

--- a/backend/src/test/java/com/study/focus/home/HomeServiceTest.java
+++ b/backend/src/test/java/com/study/focus/home/HomeServiceTest.java
@@ -1,0 +1,107 @@
+package com.study.focus.home;
+
+import com.study.focus.account.domain.Job;
+import com.study.focus.account.domain.User;
+import com.study.focus.account.domain.UserProfile;
+import com.study.focus.account.repository.UserProfileRepository;
+import com.study.focus.common.domain.Address;
+import com.study.focus.common.domain.Category;
+import com.study.focus.common.domain.File;
+import com.study.focus.common.dto.FileDetailDto;
+import com.study.focus.common.exception.BusinessException;
+import com.study.focus.common.exception.UserErrorCode;
+import com.study.focus.common.repository.FileRepository;
+import com.study.focus.common.util.S3Uploader;
+import com.study.focus.home.dto.HomeResponse;
+import com.study.focus.home.service.HomeService;
+import com.study.focus.study.domain.*;
+import com.study.focus.study.repository.BookmarkRepository;
+import com.study.focus.study.repository.StudyMemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HomeServiceTest {
+
+    @Mock private UserProfileRepository userProfileRepository;
+    @Mock private StudyMemberRepository studyMemberRepository;
+    @Mock private BookmarkRepository bookmarkRepository;
+    @Mock private S3Uploader s3Uploader;
+    @Mock private FileRepository fileRepository;
+
+    @InjectMocks private HomeService homeService;
+
+    @Test
+    @DisplayName("성공: 홈 데이터 조회")
+    void getHomeData_success() {
+        // given
+        User user = User.builder().id(1L).trustScore(80L).build();
+        File file = File.ofProfileImage(new FileDetailDto(
+                "profile.png", "test-key", "image/png", 123L));
+        UserProfile profile = UserProfile.builder()
+                .user(user)
+                .nickname("홍길동")
+                .address(new Address("경상북도", "경산시"))
+                .birthDate(LocalDate.of(2000, 1, 1))
+                .job(Job.STUDENT)
+                .preferredCategory(Category.IT)
+                .profileImage(file)
+                .build();
+
+        Study study = Study.builder().id(10L).maxMemberCount(5).build();
+        StudyProfile sp = StudyProfile.builder()
+                .study(study)
+                .title("백엔드 스터디")
+                .bio("백엔드 개발자를 위한 스터디")
+                .category(Category.IT)
+                .build();
+
+        when(userProfileRepository.findByUserId(1L)).thenReturn(Optional.of(profile));
+        when(s3Uploader.getUrlFile(anyString())).thenReturn("https://cdn.example.com/hong.png");
+        when(studyMemberRepository.findTop10StudyProfiles(PageRequest.of(0, 10)))
+                .thenReturn(List.of(sp));
+        when(bookmarkRepository.findAllByUserId(1L)).thenReturn(List.of(
+                Bookmark.builder().user(user).study(study).build()
+        ));
+        when(studyMemberRepository.countByStudyIdAndStatus(10L, StudyMemberStatus.JOINED)).thenReturn(2L);
+        when(bookmarkRepository.countByStudyId(10L)).thenReturn(31L);
+        when(studyMemberRepository.findLeaderTrustScoreByStudyId(10L)).thenReturn(Optional.of(80L));
+
+        // when
+        HomeResponse response = homeService.getHomeData(1L);
+
+        // then
+        assertThat(response.getUser().getNickname()).isEqualTo("홍길동");
+        assertThat(response.getUser().getProfileImageUrl()).isEqualTo("https://cdn.example.com/hong.png");
+        assertThat(response.getTopStudies()).hasSize(1);
+        assertThat(response.getTopStudies().get(0).getTitle()).isEqualTo("백엔드 스터디");
+        assertThat(response.getTopStudies().get(0).getBookmarkCount()).isEqualTo(31);
+        assertThat(response.getTopStudies().get(0).isBookmarked()).isTrue();
+    }
+
+    @Test
+    @DisplayName("실패: 프로필 없음 → BusinessException 발생")
+    void getHomeData_fail_profileNotFound() {
+        // given
+        when(userProfileRepository.findByUserId(1L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> homeService.getHomeData(1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(UserErrorCode.PROFILE_NOT_FOUND.getMessage());
+    }
+}

--- a/backend/src/test/java/com/study/focus/study/StudyIntegrationTest.java
+++ b/backend/src/test/java/com/study/focus/study/StudyIntegrationTest.java
@@ -292,6 +292,8 @@ class StudyIntegrationTest {
         String expectedUrl = "http://localhost/test-bucket/" + fileKey;
         FileDetailDto fileDetail = new FileDetailDto("profile.png", fileKey, "image/png", 100L);
         File profileImage = File.ofResource(null, fileDetail); // 관계 없는 필드는 null
+
+        fileRepository.save(profileImage);
         // 이미 저장된 leaderProfile의 필드만 변경
         leaderProfile.updateProfileImage(profileImage); // profileImage만 변경
         userProfileRepository.save(leaderProfile); // update 쿼리로 동작


### PR DESCRIPTION
##  작업 내용  
- **메인화면 데이터 조회 기능 구현**  
  - 사용자 프로필 정보 조회  
  - 상위 10개 스터디 프로필 조회 (북마크 여부, 참여 인원 수, 스터디 리더 신뢰도 포함)  
  - HomeService / HomeController 단위·통합 테스트 작성  

- **Cascade 옵션 제거 및 관련 수정**  
  - UserProfile → User, StudyProfile → Study, UserProfile → File 관계에서 cascade 제거  
  - Cascade 제거로 인해 발생하던 `unsaved transient instance` 오류 해결  
  - 기존 테스트 코드에서 연관 객체를 명시적으로 저장하도록 수정  

---