### PR TITLE
PR: 스터디 검색 기능 구현 및 테스트 코드 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -24,7 +24,6 @@ dependencyManagement {
 	}
 }
 
-
 configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
@@ -57,6 +56,12 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	//Querydsl 추가
+	implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+	annotationProcessor("com.querydsl:querydsl-apt:5.0.0:jakarta")
+	annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+	annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+
 	testImplementation 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -66,4 +71,9 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+//Querydsl 추가, 자동 생성된 Q클래스 gradle clean으로 제거
+clean {
+	delete file('src/main/generated')
 }

--- a/backend/src/main/generated/com/study/focus/account/domain/QOAuthCredential.java
+++ b/backend/src/main/generated/com/study/focus/account/domain/QOAuthCredential.java
@@ -1,0 +1,55 @@
+package com.study.focus.account.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QOAuthCredential is a Querydsl query type for OAuthCredential
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QOAuthCredential extends EntityPathBase<OAuthCredential> {
+
+    private static final long serialVersionUID = -55786131L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QOAuthCredential oAuthCredential = new QOAuthCredential("oAuthCredential");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final EnumPath<Provider> provider = createEnum("provider", Provider.class);
+
+    public final StringPath providerUserId = createString("providerUserId");
+
+    public final QUser user;
+
+    public QOAuthCredential(String variable) {
+        this(OAuthCredential.class, forVariable(variable), INITS);
+    }
+
+    public QOAuthCredential(Path<? extends OAuthCredential> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QOAuthCredential(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QOAuthCredential(PathMetadata metadata, PathInits inits) {
+        this(OAuthCredential.class, metadata, inits);
+    }
+
+    public QOAuthCredential(Class<? extends OAuthCredential> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.user = inits.isInitialized("user") ? new QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/account/domain/QRefreshToken.java
+++ b/backend/src/main/generated/com/study/focus/account/domain/QRefreshToken.java
@@ -1,0 +1,55 @@
+package com.study.focus.account.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QRefreshToken is a Querydsl query type for RefreshToken
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QRefreshToken extends EntityPathBase<RefreshToken> {
+
+    private static final long serialVersionUID = 968886591L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QRefreshToken refreshToken = new QRefreshToken("refreshToken");
+
+    public final DateTimePath<java.time.LocalDateTime> expiryDate = createDateTime("expiryDate", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath token = createString("token");
+
+    public final QUser user;
+
+    public QRefreshToken(String variable) {
+        this(RefreshToken.class, forVariable(variable), INITS);
+    }
+
+    public QRefreshToken(Path<? extends RefreshToken> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QRefreshToken(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QRefreshToken(PathMetadata metadata, PathInits inits) {
+        this(RefreshToken.class, metadata, inits);
+    }
+
+    public QRefreshToken(Class<? extends RefreshToken> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.user = inits.isInitialized("user") ? new QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/account/domain/QSystemCredential.java
+++ b/backend/src/main/generated/com/study/focus/account/domain/QSystemCredential.java
@@ -1,0 +1,55 @@
+package com.study.focus.account.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QSystemCredential is a Querydsl query type for SystemCredential
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QSystemCredential extends EntityPathBase<SystemCredential> {
+
+    private static final long serialVersionUID = 724906183L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QSystemCredential systemCredential = new QSystemCredential("systemCredential");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath loginId = createString("loginId");
+
+    public final StringPath password = createString("password");
+
+    public final QUser user;
+
+    public QSystemCredential(String variable) {
+        this(SystemCredential.class, forVariable(variable), INITS);
+    }
+
+    public QSystemCredential(Path<? extends SystemCredential> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QSystemCredential(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QSystemCredential(PathMetadata metadata, PathInits inits) {
+        this(SystemCredential.class, metadata, inits);
+    }
+
+    public QSystemCredential(Class<? extends SystemCredential> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.user = inits.isInitialized("user") ? new QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/account/domain/QUser.java
+++ b/backend/src/main/generated/com/study/focus/account/domain/QUser.java
@@ -1,0 +1,48 @@
+package com.study.focus.account.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QUser is a Querydsl query type for User
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUser extends EntityPathBase<User> {
+
+    private static final long serialVersionUID = 1404640812L;
+
+    public static final QUser user = new QUser("user");
+
+    public final com.study.focus.common.domain.QBaseCreatedEntity _super = new com.study.focus.common.domain.QBaseCreatedEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final DateTimePath<java.time.LocalDateTime> lastLoginAt = createDateTime("lastLoginAt", java.time.LocalDateTime.class);
+
+    public final EnumPath<LoginType> loginType = createEnum("loginType", LoginType.class);
+
+    public final NumberPath<Long> trustScore = createNumber("trustScore", Long.class);
+
+    public QUser(String variable) {
+        super(User.class, forVariable(variable));
+    }
+
+    public QUser(Path<? extends User> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QUser(PathMetadata metadata) {
+        super(User.class, metadata);
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/account/domain/QUserProfile.java
+++ b/backend/src/main/generated/com/study/focus/account/domain/QUserProfile.java
@@ -1,0 +1,70 @@
+package com.study.focus.account.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QUserProfile is a Querydsl query type for UserProfile
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUserProfile extends EntityPathBase<UserProfile> {
+
+    private static final long serialVersionUID = 1222900189L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QUserProfile userProfile = new QUserProfile("userProfile");
+
+    public final com.study.focus.common.domain.QBaseUpdatedEntity _super = new com.study.focus.common.domain.QBaseUpdatedEntity(this);
+
+    public final com.study.focus.common.domain.QAddress address;
+
+    public final DatePath<java.time.LocalDate> birthDate = createDate("birthDate", java.time.LocalDate.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final EnumPath<Job> job = createEnum("job", Job.class);
+
+    public final StringPath nickname = createString("nickname");
+
+    public final EnumPath<com.study.focus.common.domain.Category> preferredCategory = createEnum("preferredCategory", com.study.focus.common.domain.Category.class);
+
+    public final com.study.focus.common.domain.QFile profileImage;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final QUser user;
+
+    public QUserProfile(String variable) {
+        this(UserProfile.class, forVariable(variable), INITS);
+    }
+
+    public QUserProfile(Path<? extends UserProfile> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QUserProfile(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QUserProfile(PathMetadata metadata, PathInits inits) {
+        this(UserProfile.class, metadata, inits);
+    }
+
+    public QUserProfile(Class<? extends UserProfile> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.address = inits.isInitialized("address") ? new com.study.focus.common.domain.QAddress(forProperty("address")) : null;
+        this.profileImage = inits.isInitialized("profileImage") ? new com.study.focus.common.domain.QFile(forProperty("profileImage"), inits.get("profileImage")) : null;
+        this.user = inits.isInitialized("user") ? new QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/announcement/domain/QAnnouncement.java
+++ b/backend/src/main/generated/com/study/focus/announcement/domain/QAnnouncement.java
@@ -1,0 +1,66 @@
+package com.study.focus.announcement.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QAnnouncement is a Querydsl query type for Announcement
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QAnnouncement extends EntityPathBase<Announcement> {
+
+    private static final long serialVersionUID = -1318519662L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QAnnouncement announcement = new QAnnouncement("announcement");
+
+    public final com.study.focus.common.domain.QBaseTimeEntity _super = new com.study.focus.common.domain.QBaseTimeEntity(this);
+
+    public final com.study.focus.study.domain.QStudyMember author;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final StringPath description = createString("description");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.study.focus.study.domain.QStudy study;
+
+    public final StringPath title = createString("title");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QAnnouncement(String variable) {
+        this(Announcement.class, forVariable(variable), INITS);
+    }
+
+    public QAnnouncement(Path<? extends Announcement> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QAnnouncement(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QAnnouncement(PathMetadata metadata, PathInits inits) {
+        this(Announcement.class, metadata, inits);
+    }
+
+    public QAnnouncement(Class<? extends Announcement> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.author = inits.isInitialized("author") ? new com.study.focus.study.domain.QStudyMember(forProperty("author"), inits.get("author")) : null;
+        this.study = inits.isInitialized("study") ? new com.study.focus.study.domain.QStudy(forProperty("study")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/announcement/domain/QComment.java
+++ b/backend/src/main/generated/com/study/focus/announcement/domain/QComment.java
@@ -1,0 +1,61 @@
+package com.study.focus.announcement.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QComment is a Querydsl query type for Comment
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QComment extends EntityPathBase<Comment> {
+
+    private static final long serialVersionUID = 1699847220L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QComment comment = new QComment("comment");
+
+    public final com.study.focus.common.domain.QBaseCreatedEntity _super = new com.study.focus.common.domain.QBaseCreatedEntity(this);
+
+    public final QAnnouncement announcement;
+
+    public final com.study.focus.study.domain.QStudyMember commenter;
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public QComment(String variable) {
+        this(Comment.class, forVariable(variable), INITS);
+    }
+
+    public QComment(Path<? extends Comment> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QComment(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QComment(PathMetadata metadata, PathInits inits) {
+        this(Comment.class, metadata, inits);
+    }
+
+    public QComment(Class<? extends Comment> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.announcement = inits.isInitialized("announcement") ? new QAnnouncement(forProperty("announcement"), inits.get("announcement")) : null;
+        this.commenter = inits.isInitialized("commenter") ? new com.study.focus.study.domain.QStudyMember(forProperty("commenter"), inits.get("commenter")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/application/domain/QApplication.java
+++ b/backend/src/main/generated/com/study/focus/application/domain/QApplication.java
@@ -1,0 +1,63 @@
+package com.study.focus.application.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QApplication is a Querydsl query type for Application
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QApplication extends EntityPathBase<Application> {
+
+    private static final long serialVersionUID = -225209396L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QApplication application = new QApplication("application");
+
+    public final com.study.focus.common.domain.QBaseCreatedEntity _super = new com.study.focus.common.domain.QBaseCreatedEntity(this);
+
+    public final com.study.focus.account.domain.QUser applicant;
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final EnumPath<ApplicationStatus> status = createEnum("status", ApplicationStatus.class);
+
+    public final com.study.focus.study.domain.QStudy study;
+
+    public QApplication(String variable) {
+        this(Application.class, forVariable(variable), INITS);
+    }
+
+    public QApplication(Path<? extends Application> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QApplication(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QApplication(PathMetadata metadata, PathInits inits) {
+        this(Application.class, metadata, inits);
+    }
+
+    public QApplication(Class<? extends Application> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.applicant = inits.isInitialized("applicant") ? new com.study.focus.account.domain.QUser(forProperty("applicant")) : null;
+        this.study = inits.isInitialized("study") ? new com.study.focus.study.domain.QStudy(forProperty("study")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/assignment/domain/QAssignment.java
+++ b/backend/src/main/generated/com/study/focus/assignment/domain/QAssignment.java
@@ -1,0 +1,70 @@
+package com.study.focus.assignment.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QAssignment is a Querydsl query type for Assignment
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QAssignment extends EntityPathBase<Assignment> {
+
+    private static final long serialVersionUID = 944925406L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QAssignment assignment = new QAssignment("assignment");
+
+    public final com.study.focus.common.domain.QBaseTimeEntity _super = new com.study.focus.common.domain.QBaseTimeEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final com.study.focus.study.domain.QStudyMember creator;
+
+    public final StringPath description = createString("description");
+
+    public final DateTimePath<java.time.LocalDateTime> dueAt = createDateTime("dueAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final DateTimePath<java.time.LocalDateTime> startAt = createDateTime("startAt", java.time.LocalDateTime.class);
+
+    public final com.study.focus.study.domain.QStudy study;
+
+    public final StringPath title = createString("title");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QAssignment(String variable) {
+        this(Assignment.class, forVariable(variable), INITS);
+    }
+
+    public QAssignment(Path<? extends Assignment> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QAssignment(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QAssignment(PathMetadata metadata, PathInits inits) {
+        this(Assignment.class, metadata, inits);
+    }
+
+    public QAssignment(Class<? extends Assignment> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.creator = inits.isInitialized("creator") ? new com.study.focus.study.domain.QStudyMember(forProperty("creator"), inits.get("creator")) : null;
+        this.study = inits.isInitialized("study") ? new com.study.focus.study.domain.QStudy(forProperty("study")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/assignment/domain/QFeedback.java
+++ b/backend/src/main/generated/com/study/focus/assignment/domain/QFeedback.java
@@ -1,0 +1,63 @@
+package com.study.focus.assignment.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QFeedback is a Querydsl query type for Feedback
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QFeedback extends EntityPathBase<Feedback> {
+
+    private static final long serialVersionUID = 630759382L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QFeedback feedback = new QFeedback("feedback");
+
+    public final com.study.focus.common.domain.QBaseCreatedEntity _super = new com.study.focus.common.domain.QBaseCreatedEntity(this);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.study.focus.study.domain.QStudyMember reviewer;
+
+    public final NumberPath<Integer> score = createNumber("score", Integer.class);
+
+    public final QSubmission submission;
+
+    public QFeedback(String variable) {
+        this(Feedback.class, forVariable(variable), INITS);
+    }
+
+    public QFeedback(Path<? extends Feedback> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QFeedback(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QFeedback(PathMetadata metadata, PathInits inits) {
+        this(Feedback.class, metadata, inits);
+    }
+
+    public QFeedback(Class<? extends Feedback> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.reviewer = inits.isInitialized("reviewer") ? new com.study.focus.study.domain.QStudyMember(forProperty("reviewer"), inits.get("reviewer")) : null;
+        this.submission = inits.isInitialized("submission") ? new QSubmission(forProperty("submission"), inits.get("submission")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/assignment/domain/QSubmission.java
+++ b/backend/src/main/generated/com/study/focus/assignment/domain/QSubmission.java
@@ -1,0 +1,61 @@
+package com.study.focus.assignment.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QSubmission is a Querydsl query type for Submission
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QSubmission extends EntityPathBase<Submission> {
+
+    private static final long serialVersionUID = 2136809309L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QSubmission submission = new QSubmission("submission");
+
+    public final com.study.focus.common.domain.QBaseCreatedEntity _super = new com.study.focus.common.domain.QBaseCreatedEntity(this);
+
+    public final QAssignment assignment;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final StringPath description = createString("description");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.study.focus.study.domain.QStudyMember submitter;
+
+    public QSubmission(String variable) {
+        this(Submission.class, forVariable(variable), INITS);
+    }
+
+    public QSubmission(Path<? extends Submission> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QSubmission(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QSubmission(PathMetadata metadata, PathInits inits) {
+        this(Submission.class, metadata, inits);
+    }
+
+    public QSubmission(Class<? extends Submission> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.assignment = inits.isInitialized("assignment") ? new QAssignment(forProperty("assignment"), inits.get("assignment")) : null;
+        this.submitter = inits.isInitialized("submitter") ? new com.study.focus.study.domain.QStudyMember(forProperty("submitter"), inits.get("submitter")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/chat/domain/QChatMessage.java
+++ b/backend/src/main/generated/com/study/focus/chat/domain/QChatMessage.java
@@ -1,0 +1,61 @@
+package com.study.focus.chat.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QChatMessage is a Querydsl query type for ChatMessage
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QChatMessage extends EntityPathBase<ChatMessage> {
+
+    private static final long serialVersionUID = -810935501L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QChatMessage chatMessage = new QChatMessage("chatMessage");
+
+    public final com.study.focus.common.domain.QBaseCreatedEntity _super = new com.study.focus.common.domain.QBaseCreatedEntity(this);
+
+    public final com.study.focus.study.domain.QStudyMember author;
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.study.focus.study.domain.QStudy study;
+
+    public QChatMessage(String variable) {
+        this(ChatMessage.class, forVariable(variable), INITS);
+    }
+
+    public QChatMessage(Path<? extends ChatMessage> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QChatMessage(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QChatMessage(PathMetadata metadata, PathInits inits) {
+        this(ChatMessage.class, metadata, inits);
+    }
+
+    public QChatMessage(Class<? extends ChatMessage> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.author = inits.isInitialized("author") ? new com.study.focus.study.domain.QStudyMember(forProperty("author"), inits.get("author")) : null;
+        this.study = inits.isInitialized("study") ? new com.study.focus.study.domain.QStudy(forProperty("study")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/common/domain/QAddress.java
+++ b/backend/src/main/generated/com/study/focus/common/domain/QAddress.java
@@ -1,0 +1,39 @@
+package com.study.focus.common.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QAddress is a Querydsl query type for Address
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QAddress extends BeanPath<Address> {
+
+    private static final long serialVersionUID = -1212013915L;
+
+    public static final QAddress address = new QAddress("address");
+
+    public final StringPath district = createString("district");
+
+    public final StringPath province = createString("province");
+
+    public QAddress(String variable) {
+        super(Address.class, forVariable(variable));
+    }
+
+    public QAddress(Path<? extends Address> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QAddress(PathMetadata metadata) {
+        super(Address.class, metadata);
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/common/domain/QBaseCreatedEntity.java
+++ b/backend/src/main/generated/com/study/focus/common/domain/QBaseCreatedEntity.java
@@ -1,0 +1,37 @@
+package com.study.focus.common.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseCreatedEntity is a Querydsl query type for BaseCreatedEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseCreatedEntity extends EntityPathBase<BaseCreatedEntity> {
+
+    private static final long serialVersionUID = 1123525387L;
+
+    public static final QBaseCreatedEntity baseCreatedEntity = new QBaseCreatedEntity("baseCreatedEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public QBaseCreatedEntity(String variable) {
+        super(BaseCreatedEntity.class, forVariable(variable));
+    }
+
+    public QBaseCreatedEntity(Path<? extends BaseCreatedEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseCreatedEntity(PathMetadata metadata) {
+        super(BaseCreatedEntity.class, metadata);
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/common/domain/QBaseTimeEntity.java
+++ b/backend/src/main/generated/com/study/focus/common/domain/QBaseTimeEntity.java
@@ -1,0 +1,39 @@
+package com.study.focus.common.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseTimeEntity is a Querydsl query type for BaseTimeEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseTimeEntity extends EntityPathBase<BaseTimeEntity> {
+
+    private static final long serialVersionUID = 674899696L;
+
+    public static final QBaseTimeEntity baseTimeEntity = new QBaseTimeEntity("baseTimeEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+
+    public QBaseTimeEntity(String variable) {
+        super(BaseTimeEntity.class, forVariable(variable));
+    }
+
+    public QBaseTimeEntity(Path<? extends BaseTimeEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseTimeEntity(PathMetadata metadata) {
+        super(BaseTimeEntity.class, metadata);
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/common/domain/QBaseUpdatedEntity.java
+++ b/backend/src/main/generated/com/study/focus/common/domain/QBaseUpdatedEntity.java
@@ -1,0 +1,37 @@
+package com.study.focus.common.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseUpdatedEntity is a Querydsl query type for BaseUpdatedEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseUpdatedEntity extends EntityPathBase<BaseUpdatedEntity> {
+
+    private static final long serialVersionUID = 1676024478L;
+
+    public static final QBaseUpdatedEntity baseUpdatedEntity = new QBaseUpdatedEntity("baseUpdatedEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+
+    public QBaseUpdatedEntity(String variable) {
+        super(BaseUpdatedEntity.class, forVariable(variable));
+    }
+
+    public QBaseUpdatedEntity(Path<? extends BaseUpdatedEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseUpdatedEntity(PathMetadata metadata) {
+        super(BaseUpdatedEntity.class, metadata);
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/common/domain/QFile.java
+++ b/backend/src/main/generated/com/study/focus/common/domain/QFile.java
@@ -1,0 +1,75 @@
+package com.study.focus.common.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QFile is a Querydsl query type for File
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QFile extends EntityPathBase<File> {
+
+    private static final long serialVersionUID = -2045946773L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QFile file = new QFile("file");
+
+    public final QBaseCreatedEntity _super = new QBaseCreatedEntity(this);
+
+    public final com.study.focus.announcement.domain.QAnnouncement announcement;
+
+    public final com.study.focus.assignment.domain.QAssignment assignment;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final StringPath fileKey = createString("fileKey");
+
+    public final StringPath fileName = createString("fileName");
+
+    public final NumberPath<Long> fileSize = createNumber("fileSize", Long.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath isDeleted = createBoolean("isDeleted");
+
+    public final StringPath mimeType = createString("mimeType");
+
+    public final com.study.focus.resource.domain.QResource resource;
+
+    public final com.study.focus.assignment.domain.QSubmission submission;
+
+    public QFile(String variable) {
+        this(File.class, forVariable(variable), INITS);
+    }
+
+    public QFile(Path<? extends File> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QFile(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QFile(PathMetadata metadata, PathInits inits) {
+        this(File.class, metadata, inits);
+    }
+
+    public QFile(Class<? extends File> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.announcement = inits.isInitialized("announcement") ? new com.study.focus.announcement.domain.QAnnouncement(forProperty("announcement"), inits.get("announcement")) : null;
+        this.assignment = inits.isInitialized("assignment") ? new com.study.focus.assignment.domain.QAssignment(forProperty("assignment"), inits.get("assignment")) : null;
+        this.resource = inits.isInitialized("resource") ? new com.study.focus.resource.domain.QResource(forProperty("resource"), inits.get("resource")) : null;
+        this.submission = inits.isInitialized("submission") ? new com.study.focus.assignment.domain.QSubmission(forProperty("submission"), inits.get("submission")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/notification/domain/QNotification.java
+++ b/backend/src/main/generated/com/study/focus/notification/domain/QNotification.java
@@ -1,0 +1,65 @@
+package com.study.focus.notification.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QNotification is a Querydsl query type for Notification
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QNotification extends EntityPathBase<Notification> {
+
+    private static final long serialVersionUID = -750831142L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QNotification notification = new QNotification("notification");
+
+    public final com.study.focus.common.domain.QBaseCreatedEntity _super = new com.study.focus.common.domain.QBaseCreatedEntity(this);
+
+    public final com.study.focus.study.domain.QStudyMember actor;
+
+    public final EnumPath<AudienceType> audienceType = createEnum("audienceType", AudienceType.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final StringPath description = createString("description");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.study.focus.study.domain.QStudy study;
+
+    public final StringPath title = createString("title");
+
+    public QNotification(String variable) {
+        this(Notification.class, forVariable(variable), INITS);
+    }
+
+    public QNotification(Path<? extends Notification> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QNotification(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QNotification(PathMetadata metadata, PathInits inits) {
+        this(Notification.class, metadata, inits);
+    }
+
+    public QNotification(Class<? extends Notification> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.actor = inits.isInitialized("actor") ? new com.study.focus.study.domain.QStudyMember(forProperty("actor"), inits.get("actor")) : null;
+        this.study = inits.isInitialized("study") ? new com.study.focus.study.domain.QStudy(forProperty("study")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/resource/domain/QResource.java
+++ b/backend/src/main/generated/com/study/focus/resource/domain/QResource.java
@@ -1,0 +1,66 @@
+package com.study.focus.resource.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QResource is a Querydsl query type for Resource
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QResource extends EntityPathBase<Resource> {
+
+    private static final long serialVersionUID = 1162464672L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QResource resource = new QResource("resource");
+
+    public final com.study.focus.common.domain.QBaseTimeEntity _super = new com.study.focus.common.domain.QBaseTimeEntity(this);
+
+    public final com.study.focus.study.domain.QStudyMember author;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final StringPath description = createString("description");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.study.focus.study.domain.QStudy study;
+
+    public final StringPath title = createString("title");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QResource(String variable) {
+        this(Resource.class, forVariable(variable), INITS);
+    }
+
+    public QResource(Path<? extends Resource> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QResource(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QResource(PathMetadata metadata, PathInits inits) {
+        this(Resource.class, metadata, inits);
+    }
+
+    public QResource(Class<? extends Resource> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.author = inits.isInitialized("author") ? new com.study.focus.study.domain.QStudyMember(forProperty("author"), inits.get("author")) : null;
+        this.study = inits.isInitialized("study") ? new com.study.focus.study.domain.QStudy(forProperty("study")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/study/domain/QBookmark.java
+++ b/backend/src/main/generated/com/study/focus/study/domain/QBookmark.java
@@ -1,0 +1,59 @@
+package com.study.focus.study.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QBookmark is a Querydsl query type for Bookmark
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QBookmark extends EntityPathBase<Bookmark> {
+
+    private static final long serialVersionUID = -891088717L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QBookmark bookmark = new QBookmark("bookmark");
+
+    public final com.study.focus.common.domain.QBaseCreatedEntity _super = new com.study.focus.common.domain.QBaseCreatedEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QStudy study;
+
+    public final com.study.focus.account.domain.QUser user;
+
+    public QBookmark(String variable) {
+        this(Bookmark.class, forVariable(variable), INITS);
+    }
+
+    public QBookmark(Path<? extends Bookmark> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QBookmark(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QBookmark(PathMetadata metadata, PathInits inits) {
+        this(Bookmark.class, metadata, inits);
+    }
+
+    public QBookmark(Class<? extends Bookmark> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.study = inits.isInitialized("study") ? new QStudy(forProperty("study")) : null;
+        this.user = inits.isInitialized("user") ? new com.study.focus.account.domain.QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/study/domain/QStudy.java
+++ b/backend/src/main/generated/com/study/focus/study/domain/QStudy.java
@@ -1,0 +1,46 @@
+package com.study.focus.study.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QStudy is a Querydsl query type for Study
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QStudy extends EntityPathBase<Study> {
+
+    private static final long serialVersionUID = 2117245804L;
+
+    public static final QStudy study = new QStudy("study");
+
+    public final com.study.focus.common.domain.QBaseCreatedEntity _super = new com.study.focus.common.domain.QBaseCreatedEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Integer> maxMemberCount = createNumber("maxMemberCount", Integer.class);
+
+    public final EnumPath<RecruitStatus> recruitStatus = createEnum("recruitStatus", RecruitStatus.class);
+
+    public QStudy(String variable) {
+        super(Study.class, forVariable(variable));
+    }
+
+    public QStudy(Path<? extends Study> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QStudy(PathMetadata metadata) {
+        super(Study.class, metadata);
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/study/domain/QStudyMember.java
+++ b/backend/src/main/generated/com/study/focus/study/domain/QStudyMember.java
@@ -1,0 +1,65 @@
+package com.study.focus.study.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QStudyMember is a Querydsl query type for StudyMember
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QStudyMember extends EntityPathBase<StudyMember> {
+
+    private static final long serialVersionUID = -790965978L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QStudyMember studyMember = new QStudyMember("studyMember");
+
+    public final com.study.focus.common.domain.QBaseCreatedEntity _super = new com.study.focus.common.domain.QBaseCreatedEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final DateTimePath<java.time.LocalDateTime> exitedAt = createDateTime("exitedAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final EnumPath<StudyRole> role = createEnum("role", StudyRole.class);
+
+    public final EnumPath<StudyMemberStatus> status = createEnum("status", StudyMemberStatus.class);
+
+    public final QStudy study;
+
+    public final com.study.focus.account.domain.QUser user;
+
+    public QStudyMember(String variable) {
+        this(StudyMember.class, forVariable(variable), INITS);
+    }
+
+    public QStudyMember(Path<? extends StudyMember> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QStudyMember(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QStudyMember(PathMetadata metadata, PathInits inits) {
+        this(StudyMember.class, metadata, inits);
+    }
+
+    public QStudyMember(Class<? extends StudyMember> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.study = inits.isInitialized("study") ? new QStudy(forProperty("study")) : null;
+        this.user = inits.isInitialized("user") ? new com.study.focus.account.domain.QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/com/study/focus/study/domain/QStudyProfile.java
+++ b/backend/src/main/generated/com/study/focus/study/domain/QStudyProfile.java
@@ -1,0 +1,67 @@
+package com.study.focus.study.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QStudyProfile is a Querydsl query type for StudyProfile
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QStudyProfile extends EntityPathBase<StudyProfile> {
+
+    private static final long serialVersionUID = -8448867L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QStudyProfile studyProfile = new QStudyProfile("studyProfile");
+
+    public final com.study.focus.common.domain.QBaseUpdatedEntity _super = new com.study.focus.common.domain.QBaseUpdatedEntity(this);
+
+    public final com.study.focus.common.domain.QAddress address;
+
+    public final StringPath bio = createString("bio");
+
+    public final EnumPath<com.study.focus.common.domain.Category> category = createEnum("category", com.study.focus.common.domain.Category.class);
+
+    public final StringPath description = createString("description");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QStudy study;
+
+    public final StringPath title = createString("title");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QStudyProfile(String variable) {
+        this(StudyProfile.class, forVariable(variable), INITS);
+    }
+
+    public QStudyProfile(Path<? extends StudyProfile> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QStudyProfile(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QStudyProfile(PathMetadata metadata, PathInits inits) {
+        this(StudyProfile.class, metadata, inits);
+    }
+
+    public QStudyProfile(Class<? extends StudyProfile> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.address = inits.isInitialized("address") ? new com.study.focus.common.domain.QAddress(forProperty("address")) : null;
+        this.study = inits.isInitialized("study") ? new QStudy(forProperty("study")) : null;
+    }
+
+}
+

--- a/backend/src/main/java/com/study/focus/common/config/QuerydslConfig.java
+++ b/backend/src/main/java/com/study/focus/common/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package com.study.focus.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/backend/src/main/java/com/study/focus/common/dto/StudyDto.java
+++ b/backend/src/main/java/com/study/focus/common/dto/StudyDto.java
@@ -1,5 +1,6 @@
 package com.study.focus.common.dto;
 
+import com.study.focus.common.domain.Category;
 import com.study.focus.study.domain.StudyProfile;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,7 +14,7 @@ public class StudyDto {
     private int memberCount;
     private long bookmarkCount;
     private String bio;
-    private String category;
+    private Category category;
     private long trustScore;
     private boolean bookmarked;
 
@@ -29,7 +30,7 @@ public class StudyDto {
                 memberCount,
                 bookmarkCount,
                 profile.getBio(),
-                profile.getCategory().name(),
+                profile.getCategory(),
                 trustScore,
                 bookmarked
         );

--- a/backend/src/main/java/com/study/focus/study/controller/StudyQueryController.java
+++ b/backend/src/main/java/com/study/focus/study/controller/StudyQueryController.java
@@ -1,14 +1,28 @@
 package com.study.focus.study.controller;
 
+import com.study.focus.account.dto.CustomUserDetails;
+import com.study.focus.study.dto.SearchStudiesRequest;
+import com.study.focus.study.dto.SearchStudiesResponse;
+import com.study.focus.study.service.StudyQueryService;
+import com.study.focus.study.service.StudyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/studies")
+@RequiredArgsConstructor
 public class StudyQueryController {
+
+    private final StudyQueryService studyQueryService;
 
     // 스터디 그룹 검색 요청
     @GetMapping
-    public void searchStudies() {}
+    public SearchStudiesResponse searchStudies(@ModelAttribute SearchStudiesRequest request,
+                                               @AuthenticationPrincipal CustomUserDetails user) {
+        return studyQueryService.searchStudies(request, user.getUserId());
+    }
 
     // 내 그룹 데이터 가져오기
     @GetMapping("/mine")

--- a/backend/src/main/java/com/study/focus/study/domain/StudySortType.java
+++ b/backend/src/main/java/com/study/focus/study/domain/StudySortType.java
@@ -1,0 +1,9 @@
+package com.study.focus.study.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum StudySortType {
+    LATEST,            // 최신순
+    TRUST_SCORE_DESC;  // 신뢰 점수 내림차순
+}

--- a/backend/src/main/java/com/study/focus/study/dto/SearchStudiesRequest.java
+++ b/backend/src/main/java/com/study/focus/study/dto/SearchStudiesRequest.java
@@ -1,0 +1,26 @@
+package com.study.focus.study.dto;
+
+import com.study.focus.common.domain.Category;
+import com.study.focus.study.domain.StudySortType;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SearchStudiesRequest {
+    private String keyword;
+    private Category category;
+    private String province;
+    private String district;
+    private Integer page = 1;
+    private Integer limit = 10;
+    private StudySortType sort = StudySortType.LATEST; // enum 그대로 사용
+
+    public int getPageOrDefault() {
+        return (page != null && page > 0) ? page - 1 : 0;
+    }
+
+    public int getLimitOrDefault() {
+        return (limit != null && limit > 0) ? limit : 10;
+    }
+}

--- a/backend/src/main/java/com/study/focus/study/dto/SearchStudiesResponse.java
+++ b/backend/src/main/java/com/study/focus/study/dto/SearchStudiesResponse.java
@@ -1,0 +1,29 @@
+package com.study.focus.study.dto;
+
+import com.study.focus.common.dto.StudyDto;
+import com.study.focus.study.domain.StudySortType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SearchStudiesResponse {
+
+    private List<StudyDto> studies; // 공용 DTO 사용
+    private Meta meta;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class Meta {
+        private int page;
+        private int limit;
+        private long totalCount;
+        private int totalPages;
+        private StudySortType sort;
+    }
+}

--- a/backend/src/main/java/com/study/focus/study/repository/StudyRepository.java
+++ b/backend/src/main/java/com/study/focus/study/repository/StudyRepository.java
@@ -3,5 +3,5 @@ package com.study.focus.study.repository;
 import com.study.focus.study.domain.Study;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StudyRepository extends JpaRepository<Study, Long> {
+public interface StudyRepository extends JpaRepository<Study, Long>, StudyRepositoryCustom {
 }

--- a/backend/src/main/java/com/study/focus/study/repository/StudyRepositoryCustom.java
+++ b/backend/src/main/java/com/study/focus/study/repository/StudyRepositoryCustom.java
@@ -1,0 +1,17 @@
+package com.study.focus.study.repository;
+
+import com.study.focus.common.domain.Category;
+import com.study.focus.common.dto.StudyDto;
+import com.study.focus.study.domain.StudySortType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface StudyRepositoryCustom {
+    Page<StudyDto> searchStudies(String keyword,
+                                 Category category,
+                                 String province,
+                                 String district,
+                                 Long userId,
+                                 StudySortType sortType,
+                                 Pageable pageable);
+}

--- a/backend/src/main/java/com/study/focus/study/repository/StudyRepositoryImpl.java
+++ b/backend/src/main/java/com/study/focus/study/repository/StudyRepositoryImpl.java
@@ -1,0 +1,104 @@
+package com.study.focus.study.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.study.focus.account.domain.QUser;
+import com.study.focus.common.domain.Category;
+import com.study.focus.common.dto.StudyDto;
+import com.study.focus.study.domain.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class StudyRepositoryImpl implements StudyRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<StudyDto> searchStudies(String keyword,
+                                        Category category,
+                                        String province,
+                                        String district,
+                                        Long userId,
+                                        StudySortType sortType,
+                                        Pageable pageable) {
+        QStudy study = QStudy.study;
+        QStudyProfile profile = QStudyProfile.studyProfile;
+        QStudyMember member = QStudyMember.studyMember;
+        QBookmark bookmark = QBookmark.bookmark;
+        QUser leaderUser = new QUser("leaderUser");
+        QStudyMember leaderMember = new QStudyMember("leaderMember");
+
+        BooleanBuilder where = new BooleanBuilder();
+        if (keyword != null && !keyword.isBlank()) {
+            where.and(profile.title.containsIgnoreCase(keyword)
+                    .or(profile.bio.containsIgnoreCase(keyword)));
+        }
+        if (category != null) {
+            where.and(profile.category.eq(category));
+        }
+        if (province != null && !province.isBlank()) {
+            where.and(profile.address.province.eq(province));
+        }
+        if (district != null && !district.isBlank()) {
+            where.and(profile.address.district.eq(district));
+        }
+
+        // content 조회 (방장 trustScore 기준)
+        List<StudyDto> content = queryFactory
+                .select(Projections.constructor(StudyDto.class,
+                        study.id,
+                        profile.title,
+                        study.maxMemberCount,
+                        member.id.countDistinct().intValue(),
+                        bookmark.id.countDistinct(),
+                        profile.bio,
+                        profile.category,
+                        leaderUser.trustScore,
+                        JPAExpressions.selectOne()
+                                .from(bookmark)
+                                .where(bookmark.study.eq(study)
+                                        .and(bookmark.user.id.eq(userId)))
+                                .exists()
+                ))
+                .from(study)
+                .join(profile).on(profile.study.eq(study))
+                .leftJoin(member).on(member.study.eq(study))
+                .leftJoin(bookmark).on(bookmark.study.eq(study))
+                .join(leaderMember).on(leaderMember.study.eq(study)
+                        .and(leaderMember.role.eq(StudyRole.LEADER)))
+                .join(leaderMember.user, leaderUser)
+                .where(where)
+                .groupBy(study.id, profile.title, study.maxMemberCount,
+                        profile.bio, profile.category, leaderUser.trustScore)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(toOrderSpecifier(sortType, study, leaderUser))
+                .fetch();
+
+        Long total = queryFactory
+                .select(study.countDistinct())
+                .from(study)
+                .join(profile).on(profile.study.eq(study))
+                .where(where)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total == null ? 0 : total);
+    }
+
+    private OrderSpecifier<?> toOrderSpecifier(StudySortType sortType,
+                                               QStudy study,
+                                               QUser user) {
+        return switch (sortType) {
+            case LATEST -> study.createdAt.desc();
+            case TRUST_SCORE_DESC -> user.trustScore.desc(); // 방장 trustScore 기준 정렬
+        };
+    }
+}

--- a/backend/src/main/java/com/study/focus/study/service/BookmarkService.java
+++ b/backend/src/main/java/com/study/focus/study/service/BookmarkService.java
@@ -23,11 +23,6 @@ public class BookmarkService {
     private final UserRepository userRepository;
     private final StudyRepository studyRepository;
 
-    // 내 찜 목록 가져오기
-    public void getBookmarks(Long userId) {
-        // TODO: 내가 찜한 스터디 목록 조회
-    }
-
     // 스터디 그룹 찜하기
     public void addBookmark(Long userId, Long studyId) {
 

--- a/backend/src/main/java/com/study/focus/study/service/StudyQueryService.java
+++ b/backend/src/main/java/com/study/focus/study/service/StudyQueryService.java
@@ -1,0 +1,87 @@
+package com.study.focus.study.service;
+
+import com.study.focus.account.repository.UserProfileRepository;
+import com.study.focus.account.repository.UserRepository;
+import com.study.focus.application.repository.ApplicationRepository;
+import com.study.focus.common.dto.StudyDto;
+import com.study.focus.common.util.S3Uploader;
+import com.study.focus.study.domain.StudyProfile;
+import com.study.focus.study.domain.StudySortType;
+import com.study.focus.study.dto.SearchStudiesRequest;
+import com.study.focus.study.dto.SearchStudiesResponse;
+import com.study.focus.study.repository.BookmarkRepository;
+import com.study.focus.study.repository.StudyMemberRepository;
+import com.study.focus.study.repository.StudyProfileRepository;
+import com.study.focus.study.repository.StudyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StudyQueryService {
+
+    private final StudyRepository studyRepository;
+    private final StudyProfileRepository studyProfileRepository;
+    private final StudyMemberRepository studyMemberRepository;
+    private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
+    private final S3Uploader s3Uploader;
+    private final BookmarkRepository bookmarkRepository;
+
+    // 스터디 그룹 검색 요청
+    @Transactional(readOnly = true)
+    public SearchStudiesResponse searchStudies(SearchStudiesRequest request, Long userId) {
+        Pageable pageable = PageRequest.of(
+                request.getPageOrDefault(),
+                request.getLimitOrDefault(),
+                getSort(request.getSort())
+        );
+
+        Page<StudyDto> pageResult = studyRepository.searchStudies(
+                request.getKeyword(),
+                request.getCategory(),
+                request.getProvince(),
+                request.getDistrict(),
+                userId,
+                request.getSort(),
+                pageable
+        );
+
+        SearchStudiesResponse.Meta meta = SearchStudiesResponse.Meta.builder()
+                .page(request.getPage())
+                .limit(request.getLimitOrDefault())
+                .totalCount(pageResult.getTotalElements())
+                .totalPages(pageResult.getTotalPages())
+                .sort(request.getSort())
+                .build();
+
+        return SearchStudiesResponse.builder()
+                .studies(pageResult.getContent())
+                .meta(meta)
+                .build();
+    }
+
+    private Sort getSort(StudySortType sortType) {
+        return switch (sortType) {
+            case LATEST -> Sort.by(Sort.Direction.DESC, "createdAt");
+            case TRUST_SCORE_DESC -> Sort.by(Sort.Direction.DESC, "trustScore");
+        };
+    }
+
+    // 내 그룹 데이터 가져오기
+    public void getMyStudies(Long userId) {
+        // TODO: 내가 가입한 스터디 조회
+    }
+
+    // 내 찜 목록 가져오기
+    public void getBookmarks(Long userId) {
+        // TODO: 내가 찜한 스터디 목록 조회
+    }
+}

--- a/backend/src/main/java/com/study/focus/study/service/StudyService.java
+++ b/backend/src/main/java/com/study/focus/study/service/StudyService.java
@@ -8,18 +8,21 @@ import com.study.focus.application.domain.Application;
 import com.study.focus.application.domain.ApplicationStatus;
 import com.study.focus.application.repository.ApplicationRepository;
 import com.study.focus.common.domain.Address;
+import com.study.focus.common.dto.StudyDto;
 import com.study.focus.common.exception.BusinessException;
 import com.study.focus.common.exception.CommonErrorCode;
 import com.study.focus.common.exception.UserErrorCode;
 import com.study.focus.common.util.S3Uploader;
 import com.study.focus.study.domain.*;
-import com.study.focus.study.dto.CreateStudyRequest;
-import com.study.focus.study.dto.GetStudyProfileResponse;
-import com.study.focus.study.dto.UpdateStudyProfileRequest;
+import com.study.focus.study.dto.*;
+import com.study.focus.study.repository.BookmarkRepository;
 import com.study.focus.study.repository.StudyMemberRepository;
 import com.study.focus.study.repository.StudyProfileRepository;
 import com.study.focus.study.repository.StudyRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -172,15 +175,5 @@ public class StudyService {
     // 그룹 삭제
     public void deleteStudy(Long studyId) {
         // TODO: 스터디 삭제
-    }
-
-    // 스터디 그룹 검색 요청
-    public void searchStudies() {
-        // TODO: 스터디 검색
-    }
-
-    // 내 그룹 데이터 가져오기
-    public void getMyStudies(Long userId) {
-        // TODO: 내가 가입한 스터디 조회
     }
 }

--- a/backend/src/test/java/com/study/focus/home/HomeControllerTest.java
+++ b/backend/src/test/java/com/study/focus/home/HomeControllerTest.java
@@ -122,17 +122,6 @@ class HomeControllerTest {
                 .thenReturn("https://test-bucket.s3.ap-northeast-2.amazonaws.com/profile.png");
     }
 
-    @AfterEach
-    void tearDown() {
-        bookmarkRepository.deleteAll();
-        studyMemberRepository.deleteAll();
-        studyProfileRepository.deleteAll();
-        studyRepository.deleteAll();
-        userProfileRepository.deleteAll();
-        userRepository.deleteAll();
-        fileRepository.deleteAll();
-    }
-
     @Test
     @DisplayName("성공: 홈 데이터 조회 API")
     void getHomeData_success() throws Exception {

--- a/backend/src/test/java/com/study/focus/home/HomeControllerTest.java
+++ b/backend/src/test/java/com/study/focus/home/HomeControllerTest.java
@@ -170,20 +170,6 @@ class HomeControllerTest {
     }
 
     @Test
-    @DisplayName("성공: 스터디 없는 경우 → topStudies = []")
-    void getHomeData_success_noStudies() throws Exception {
-        bookmarkRepository.deleteAll();
-        studyMemberRepository.deleteAll();
-        studyProfileRepository.deleteAll();
-        studyRepository.deleteAll();
-
-        mockMvc.perform(get("/api/home")
-                        .with(user(new CustomUserDetails(user.getId()))))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.topStudies").isEmpty());
-    }
-
-    @Test
     @DisplayName("성공: 스터디 10개 초과 → 상위 10개만 반환")
     void getHomeData_success_top10Only() throws Exception {
         IntStream.range(0, 15).forEach(i -> {

--- a/backend/src/test/java/com/study/focus/study/controller/StudyQueryControllerTest.java
+++ b/backend/src/test/java/com/study/focus/study/controller/StudyQueryControllerTest.java
@@ -1,0 +1,118 @@
+package com.study.focus.study.controller;
+
+import com.study.focus.account.config.jwt.TokenProvider;
+import com.study.focus.account.domain.User;
+import com.study.focus.account.repository.UserRepository;
+import com.study.focus.common.domain.Address;
+import com.study.focus.common.domain.Category;
+import com.study.focus.study.domain.Study;
+import com.study.focus.study.domain.StudyMember;
+import com.study.focus.study.domain.StudyProfile;
+import com.study.focus.study.domain.StudyRole;
+import com.study.focus.study.repository.StudyMemberRepository;
+import com.study.focus.study.repository.StudyProfileRepository;
+import com.study.focus.study.repository.StudyRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class StudyQueryControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private UserRepository userRepository;
+    @Autowired private StudyRepository studyRepository;
+    @Autowired private StudyProfileRepository studyProfileRepository;
+    @Autowired private StudyMemberRepository studyMemberRepository;
+    @Autowired private TokenProvider tokenProvider;
+
+    @Test
+    @DisplayName("회원가입 후 로그인 + 스터디 생성 → 검색 API 호출 시 200 OK와 결과 반환")
+    void searchStudies_returnsJsonResponse_withRegisterAndLogin() throws Exception {
+        // 1. 회원가입
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "loginId": "testuser",
+                              "password": "1234",
+                              "nickname": "tester"
+                            }
+                            """))
+                .andExpect(status().isOk());
+
+        // 2. 로그인 → Redirect URL 추출
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "loginId": "testuser",
+                              "password": "1234"
+                            }
+                            """))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
+
+        String redirectUrl = loginResult.getResponse().getRedirectedUrl();
+
+        // 3. Redirect URL에서 accessToken 파싱
+        URI uri = new URI(redirectUrl);
+        String query = uri.getQuery(); // e.g. token=xxxx&profileExists=false
+        Map<String, String> params = Arrays.stream(query.split("&"))
+                .map(s -> s.split("="))
+                .collect(Collectors.toMap(a -> a[0], a -> a[1]));
+
+        String accessToken = params.get("token");
+
+        // 4. 테스트용 Study/StudyProfile/StudyMember 데이터 삽입
+        Long userId = tokenProvider.getUserIdFromToken(accessToken);
+        User leader = userRepository.findById(userId).orElseThrow();
+
+
+        Study study = Study.builder()
+                .maxMemberCount(10)
+                .build();
+        studyRepository.save(study);
+
+        StudyProfile profile = StudyProfile.builder()
+                .study(study)
+                .title("알고리즘")
+                .bio("백준 같이 풀기")
+                .category(Category.IT)
+                .address(new Address("경상북도", "경산시")) 
+                .build();
+        studyProfileRepository.save(profile);
+
+        StudyMember member = StudyMember.builder()
+                .study(study)
+                .user(leader)
+                .role(StudyRole.LEADER)
+                .build();
+        studyMemberRepository.save(member);
+
+        // 5. 토큰 넣고 /api/studies 요청
+        mockMvc.perform(get("/api/studies")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("keyword", "알고리즘")
+                        .param("page", "1")
+                        .param("limit", "10")
+                        .param("sort", "LATEST"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.studies[0].title").value("알고리즘"));
+    }
+}

--- a/backend/src/test/java/com/study/focus/study/service/StudyQueryServiceIntegrationTest.java
+++ b/backend/src/test/java/com/study/focus/study/service/StudyQueryServiceIntegrationTest.java
@@ -1,0 +1,140 @@
+package com.study.focus.study.service;
+
+import com.study.focus.account.domain.User;
+import com.study.focus.account.repository.UserRepository;
+import com.study.focus.common.domain.Address;
+import com.study.focus.common.domain.Category;
+import com.study.focus.study.domain.*;
+import com.study.focus.study.dto.SearchStudiesRequest;
+import com.study.focus.study.dto.SearchStudiesResponse;
+import com.study.focus.study.repository.BookmarkRepository;
+import com.study.focus.study.repository.StudyMemberRepository;
+import com.study.focus.study.repository.StudyProfileRepository;
+import com.study.focus.study.repository.StudyRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class StudyQueryServiceIntegrationTest {
+
+    @Autowired private StudyQueryService studyQueryService;
+    @Autowired private StudyRepository studyRepository;
+    @Autowired private StudyProfileRepository studyProfileRepository;
+    @Autowired private StudyMemberRepository studyMemberRepository;
+    @Autowired private BookmarkRepository bookmarkRepository;
+    @Autowired private UserRepository userRepository;
+
+    private Long userId;
+
+    @BeforeEach
+    void setUp() {
+        // 방장 유저
+        User leader1 = User.builder().trustScore(80).build();
+        User leader2 = User.builder().trustScore(95).build();
+
+        // 북마크 유저
+        User bookmarker = User.builder().trustScore(30).build();
+
+        userRepository.saveAll(List.of(leader1, leader2, bookmarker));
+
+        // 스터디 1
+        Study study1 = Study.builder()
+                .maxMemberCount(10)
+                .build();
+
+        StudyProfile profile1 = StudyProfile.builder()
+                .study(study1)
+                .title("알고리즘 스터디")
+                .bio("백준 같이 풀기")
+                .category(Category.IT)
+                .address(new Address("경상북도", "경산시"))
+                .build();
+
+        StudyMember member1 = StudyMember.builder()
+                .study(study1)
+                .user(leader1)   // 이제 영속 상태 User 참조
+                .role(StudyRole.LEADER)
+                .build();
+
+        // 스터디 2
+        Study study2 = Study.builder()
+                .maxMemberCount(15)
+                .build();
+
+        StudyProfile profile2 = StudyProfile.builder()
+                .study(study2)
+                .title("네트워크 스터디")
+                .bio("OSI 7계층")
+                .category(Category.IT)
+                .address(new Address("경상북도", "경산시"))
+                .build();
+
+        StudyMember member2 = StudyMember.builder()
+                .study(study2)
+                .user(leader2)   // 영속 상태 User 참조
+                .role(StudyRole.LEADER)
+                .build();
+
+        // 저장
+        studyRepository.saveAll(List.of(study1, study2));
+        studyProfileRepository.saveAll(List.of(profile1, profile2));
+        studyMemberRepository.saveAll(List.of(member1, member2));
+
+        userId = bookmarker.getId();
+
+        // bookmarker가 study1 북마크
+        Bookmark bookmark = Bookmark.builder()
+                .user(bookmarker)  // 영속 상태 User 참조
+                .study(study1)
+                .build();
+        bookmarkRepository.save(bookmark);
+    }
+
+    @Test
+    @DisplayName("키워드 검색 동작 확인")
+    void searchByKeyword() {
+        SearchStudiesRequest req = new SearchStudiesRequest();
+        req.setKeyword("알고리즘");
+
+        SearchStudiesResponse res = studyQueryService.searchStudies(req, userId);
+        assertThat(res.getStudies()).hasSize(1);
+        assertThat(res.getStudies().get(0).getTitle()).contains("알고리즘");
+    }
+
+    @Test
+    @DisplayName("카테고리 검색 동작 확인")
+    void searchByCategory() {
+        SearchStudiesRequest req = new SearchStudiesRequest();
+        req.setCategory(Category.IT);
+
+        SearchStudiesResponse res = studyQueryService.searchStudies(req, userId);
+        assertThat(res.getStudies()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("정렬: 방장 trustScore 내림차순")
+    void sortByLeaderTrustScore() {
+        SearchStudiesRequest req = new SearchStudiesRequest();
+        req.setSort(StudySortType.TRUST_SCORE_DESC);
+
+        SearchStudiesResponse res = studyQueryService.searchStudies(req, userId);
+        assertThat(res.getStudies().get(0).getTrustScore())
+                .isGreaterThanOrEqualTo(res.getStudies().get(1).getTrustScore());
+    }
+
+    @Test
+    @DisplayName("bookmarked 여부 확인")
+    void bookmarkedCheck() {
+        SearchStudiesResponse res = studyQueryService.searchStudies(new SearchStudiesRequest(), userId);
+        assertThat(res.getStudies().stream().anyMatch(s -> s.isBookmarked())).isTrue();
+    }
+}

--- a/backend/src/test/java/com/study/focus/study/service/StudyQueryServiceUnitTest.java
+++ b/backend/src/test/java/com/study/focus/study/service/StudyQueryServiceUnitTest.java
@@ -1,0 +1,52 @@
+package com.study.focus.study.service;
+
+import com.study.focus.common.dto.StudyDto;
+import com.study.focus.common.domain.Category;
+import com.study.focus.study.domain.StudySortType;
+import com.study.focus.study.dto.SearchStudiesRequest;
+import com.study.focus.study.dto.SearchStudiesResponse;
+import com.study.focus.study.repository.StudyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StudyQueryServiceUnitTest {
+
+    @Mock
+    private StudyRepository studyRepository;
+
+    @InjectMocks
+    private StudyQueryService studyQueryService;
+
+    @Test
+    void searchStudies_mapsRepositoryResultToResponse() {
+        StudyDto dto = new StudyDto(1L, "알고리즘", 10, 5, 3,
+                "PS", Category.IT, 80, true);
+
+        Page<StudyDto> page = new PageImpl<>(List.of(dto), PageRequest.of(0, 10), 1);
+        when(studyRepository.searchStudies(any(), any(), any(), any(), anyLong(), any(), any()))
+                .thenReturn(page);
+
+        SearchStudiesRequest req = new SearchStudiesRequest();
+        req.setKeyword("알고리즘");
+        req.setCategory(Category.IT);
+        req.setSort(StudySortType.LATEST);
+
+        SearchStudiesResponse res = studyQueryService.searchStudies(req, 1L);
+
+        assertThat(res.getStudies()).hasSize(1);
+        assertThat(res.getStudies().get(0).getTitle()).isEqualTo("알고리즘");
+        assertThat(res.getMeta().getSort()).isEqualTo(StudySortType.LATEST);
+    }
+}


### PR DESCRIPTION
## 작업 내용
- **동적 쿼리 기반 스터디 검색 기능 구현**
  - QueryDSL을 사용해 `keyword`, `category`, `province`, `district`, `sort` 조건별 검색 지원
  - 스터디, 프로필, 멤버, 북마크 엔티티를 조인하여 DTO 매핑
  - 방장 신뢰도(`trustScore`) 기반 정렬 옵션 추가
  - 북마크 여부(Boolean) 조회 기능 추가

- **통합 테스트 작성**
  - 회원가입 → 로그인 → accessToken 발급 → 스터디 검색 API 호출 플로우 검증
  - 테스트 데이터 삽입 후 검색 결과 정상 반환 확인
  - 케이스별 테스트
    - 키워드 검색
    - 카테고리 검색
    - 정렬(방장 신뢰도 내림차순)
    - 북마크 여부 확인

## 기타 참고사항
- 추후 필터 조건(기간, 모집상태 등) 확장이 용이하도록 QueryDSL 기반 동적 쿼리로 구현
- `UserRepository` 활용해 로그인한 사용자 정보 기반 북마크 여부 확인
- 홈 화면 데이터 가져오기에서 사용한 StudyDto 재사용